### PR TITLE
Viele Mini-Änderungen

### DIFF
--- a/_01-Logik.tex
+++ b/_01-Logik.tex
@@ -12,7 +12,7 @@
 
 
 \begin{nota}[Zeichen mit einer konkreten Bedeutung versehen] \label{zeichendefinieren}
-    Gelegentlich ist es bequem, ein konkretes, kompliziert definiertes Objekt mit einem Zeichen zu bezeichnen. Beispielsweise lässt sich mit Methoden der Analysis\footnote{Genauer gesagt: der \emph{Differenzialrechnung}, die in der Erstsemestervorlesung „Analysis 1“ oder bereits in der Schule vermittelt wird. Siehe auch \cref{bsp:exverwendung}.} zeigen, dass die Gleichung $x^5=x+1$ genau eine Lösung in den reellen Zahlen besitzt, wohingegen sich mit Methoden der Algebra zeigen lässt, dass sich diese Lösung nicht mit den Operationen $+$, $-$, $\cdot$, $:$, $\sqrt{}$ konstruieren lässt\footnote{Algebraiker sagen: \emph{die Gleichung $x^5=x+1$ ist nicht auflösbar}. Mit der Auflösbarkeit von Gleichungen beschäftigt sich die sogenannte \emph{Galoistheorie}, die in Heidelberg typischerweise in der Drittsemestervorlesung „Algebra 1“ vermittelt wird.}. Möchte man nun mit dieser Lösung arbeiten, so ist es umständlich, immer wieder „die eindeutige reelle Lösung der Gleichung $x^5=x+1$“ zu schreiben und es ist bequemer, einen Buchstaben zu verwenden. Dafür benutzen Mathematiker einen Imperativ:
+    Gelegentlich ist es bequem, ein konkretes, kompliziert definiertes Objekt mit einem Zeichen zu bezeichnen. Beispielsweise lässt sich mit Methoden der Analysis\footnote{Genauer gesagt: der \emph{Differenzialrechnung}, die in der Erstsemestervorlesung „Analysis 1“ oder bereits in der Schule vermittelt wird. Siehe auch \cref{bsp:exverwendung}.} zeigen, dass die Gleichung $x^5=x+1$ genau eine Lösung in den reellen Zahlen besitzt, wohingegen sich mit Methoden der Algebra zeigen lässt, dass sich diese Lösung nicht mit den Operationen $+$, $-$, $\cdot$, $:$, $\sqrt{}$ konstruieren lässt\footnote{Algebraiker sagen: \emph{die Gleichung $x^5=x+1$ ist nicht auflösbar}. Mit der Auflösbarkeit von Gleichungen beschäftigt sich die sogenannte \emph{Galoistheorie}, die in Heidelberg typischerweise in der Drittsemestervorlesung „Algebra 1“ vermittelt wird.}. Möchte man nun mit dieser Lösung arbeiten, so ist es umständlich, immer wieder „die eindeutige reelle Lösung der Gleichung $x^5=x+1$“ zu schreiben und es ist bequemer, einen Buchstaben zu verwenden. Dafür benutzen Mathematiker einen Konjunktiv\footnote{Um genau zu sein, einen \emph{Jussiv}, der im Deutschen mit dem Konjunktiv ausgedrückt wird.}:
     \begin{quote}
         „Sei $\xi$ die eindeutige reelle Lösung der Gleichung $x^5=x+1$.“  
     \end{quote}
@@ -105,7 +105,7 @@
 
 
 \begin{de}[* Variablensubstitution] \label{def:substitution}
-    Sei $t(x)$ ein Term in der Variablen $x$. Ist $y$ ein Objekt vom Typ der Variablen $x$ oder ein weiterer Term, dessen Typ mit demjenigen der Variable $x$ übereinstimmt, so $y$ für die Variable $x$ \textbf{eingesetzt} (oder auch: \textbf{substituiert}) werden. Der so entstandene Term wird meist notiert durch
+    Sei $t(x)$ ein Term in der Variablen $x$. Ist $y$ ein Objekt vom Typ der Variablen $x$ oder ein weiterer Term, dessen Typ mit demjenigen der Variable $x$ übereinstimmt, so kann $y$ für die Variable $x$ \textbf{eingesetzt} (oder auch: \textbf{substituiert}) werden. Der so entstandene Term wird meist notiert durch
     \begin{align*}
         t(y) && (\text{lies: „$t$ von $y$“})
     \end{align*}
@@ -296,7 +296,7 @@ Es werden nun die gebräuchlichen Junktoren vorgestellt.
 \end{bem}
 
 
-\begin{de}[Äquivalenz] \index{Äquivalenz (von Aussagen)}
+\begin{de}[Äquivalenz] \index{Aequivalenz (von Aussagen)@Äquivalenz (von Aussagen)}
     Zwei Aussagen $A$ und $B$ lassen sich zur \textbf{Äquivalenz}
     \begin{align*}
         A\leftrightarrow B  && (\text{lies: „$A$ ist äquivalent zu $B$“})
@@ -351,7 +351,7 @@ Es werden nun die gebräuchlichen Junktoren vorgestellt.
     Es gibt noch weitere Junktoren wie etwa:
     \begin{itemize}
         \item Der Sheffer-Strich\footnote{\href{https://de.wikipedia.org/wiki/Henry_Maurice_Sheffer}{Henry Maurice Sheffer (1882-1964)}} „$A\mid B$“ (lies: „Nicht sowohl $A$ als auch $B$“). In der Informatik spricht man auch von der NAND-Verknüpfung.
-        \item Die Peirce-Funktion „$A\downarrow B$“ (lies: „Weder $A$ noch $B$“). In der Informatik spricht man auch von der NOR-Verknüpfung.
+        \item Die Peirce-Funktion\footnote{\href{https://de.wikipedia.org/wiki/Charles_Sanders_Peirce}{Charles Sanders Peirce (1839-1914)}} „$A\downarrow B$“ (lies: „Weder $A$ noch $B$“). In der Informatik spricht man auch von der NOR-Verknüpfung.
     \end{itemize}
     NAND und NOR besitzen die besondere Eigenschaft, dass sich in der Schaltalgebra jeder andere Junktor allein durch NAND's bzw. \href{https://de.wikipedia.org/wiki/NOR-Gatter#Logiksynthese}{allein durch NOR's} konstruieren lässt. In dieser Hinsicht sind sie für die technische Informatik von großer Bedeutung. Für die Mathematik sind sie dagegen nahezu irrelevant.
 \end{vorschau}
@@ -535,7 +535,7 @@ Vermöge ihrer Extension bestimmt jede Eigenschaft eine Menge. Umgekehrt bestimm
 \begin{bem}[* freie Variablen vs. gebundene Variablen] \label{gebundenevariable} \index{freie Variable} \index{gebundene Variable}
     Im Ausdruck „$x$ ist eine negative Zahl“ kann für die Variable $x$ eine beliebige reelle Zahl eingesetzt werden. Ebenso z.B. in der Gleichung „$x(x+1)=2$“ (unter Umständen erhielte man falsche Aussagen). Um die Freiheit in der Belegung einer Variable zu betonen, spricht man auch von einer \textbf{freien Variable}. Dagegen ist der Buchstabe „$n$“ im Ausdruck „Für jede gerade natürliche Zahl $n$ ist auch $n^2$ eine gerade Zahl“ oder der Buchstabe „$x$“ in „$\exists x: x(x+1)=2$“ keine Variable mehr, da es keinen Sinn ergäbe, für sie ein konkretes Objekt einzusetzen, wie etwa
     \begin{align*}
-        \forall 5:\ 5(5+1) = 2 && (\text{dieser Ausdruck ist syntaktisch unzulässig})
+        \exists 5:\ 5(5+1) = 2 && (\text{dieser Ausdruck ist syntaktisch unzulässig})
     \end{align*}
     Man sagt, „die Variable wird durch den Quantor gebunden“ und nennt das Zeichen „$x$“ in „$\forall x: x(x+1)=2$“ eine \textbf{gebundene Variable}. Es handelt sich nicht mehr um eine Variable im Sinn von \cref{def:variable}, sondern nur noch um ein „Dummy-Zeichen“, das in der Umgangssprache sogar oftmals vermieden werden kann. So würde man den Ausdruck
         \[ \forall x:\ (x\ \text{ist ein Mensch})\to (x\ \text{ist sterblich}) \]
@@ -566,7 +566,7 @@ Vermöge ihrer Extension bestimmt jede Eigenschaft eine Menge. Umgekehrt bestimm
 \begin{nota}[Schreibkonvention bei mehreren Quantoren]
     Verwende ich mehrere Quantoren unmittelbar hintereinander, schreibe ich den Doppelpunkt oft nur hinter den letzten Quantor:
     \begin{align*}
-        \exists y\ \forall x& :\ x < y && (\text{lies: „Es gibt ein $y$, sodass für alle $x$ gilt, dass $x<y$“}) \\
+        \exists y\ \forall x& :\ x < y && (\text{lies: „Es gibt ein $y$ derart, dass für alle $x$ gilt, dass $x<y$“}) \\
         \forall x\ \exists y& :\ x < y && (\text{lies: „Für jedes $x$ gibt es ein $y$, für das $x<y$ gilt“})  
     \end{align*}
     Einige Autoren lassen die Doppelpunkte hinter Quantoren auch ganz weg.
@@ -643,7 +643,7 @@ Vermöge ihrer Extension bestimmt jede Eigenschaft eine Menge. Umgekehrt bestimm
 
 
 \begin{vorschau}[Bivalenzprinzip] \label{bivalenz} \index{Bivalenzprinzip}
-    In der klassischen Aussagenlogik trägt die Menge der Wahrheitswerte in natürlicher Weise die Struktur einer sogenannten „\href{https://en.wikipedia.org/wiki/Boolean_algebra_(structure)}{Boolschen Algebra}“\footnote{\href{https://de.wikipedia.org/wiki/George_Boole}{George Boole (1815-1864)}} bzw. einer sogenannten „\href{https://ncatlab.org/nlab/show/Heyting+algebra}{Heyting-Algebren}“\footnote{\href{https://de.wikipedia.org/wiki/Arend_Heyting}{Arend Heyting (1898-1980)}}. Eine Interpretation einer Aussage ist die Zuweisung eines Wahrheitswerts nach gewissen Regeln. 
+    In der klassischen Aussagenlogik trägt die Menge der Wahrheitswerte in natürlicher Weise die Struktur einer sogenannten „\href{https://en.wikipedia.org/wiki/Boolean_algebra_(structure)}{Boolschen Algebra}“\footnote{\href{https://de.wikipedia.org/wiki/George_Boole}{George Boole (1815-1864)}} bzw. einer sogenannten „\href{https://ncatlab.org/nlab/show/Heyting+algebra}{Heyting-Algebra}“\footnote{\href{https://de.wikipedia.org/wiki/Arend_Heyting}{Arend Heyting (1898-1980)}}. Eine Interpretation einer Aussage ist die Zuweisung eines Wahrheitswerts nach gewissen Regeln.
     
     Da sich ein Bit stets genau in einem der beiden Zustände $1$ oder $0$ befindet, besteht „die Boolsche Algebra“ der Informatiker aus genau diesen beiden Wahrheitswerten, auch ``true'' und ``false'' genannt. Auch in diesem Vorkurs beschränken wir uns auf diejenige boolsche Algebra, die ausschließlich aus den beiden Wahrheitswerten „wahr“ und „falsch“ besteht. Diese Einschränkung heißt auch das \emph{Prinzip der Zweiwertigkeit} oder \textbf{Bivalenzprinzip}\footnote{Philosophen sprechen auch vom „Satz vom ausgeschlossenen Dritten“. Dieser besitzt in der mathematischen Logik aber eine andere Bedeutung als das Bivalenzprinzip, siehe \cref{excludedmiddle}}.
     
@@ -785,7 +785,7 @@ Vermöge ihrer Extension bestimmt jede Eigenschaft eine Menge. Umgekehrt bestimm
     Seien $A,B$ zwei beliebige Aussagen. Dann gilt:
     \begin{enumerate}
         \item Genau dann ist $A$ unerfüllbar, wenn $\neg A$ eine Tautologie ist.
-        \item Genau dann ist $A\leftrightarrow B$ eine Tautologie, wenn die Interpretationen, unter denen $A$ wahr ist, genau dieselben sind, unter denen $B$ wahr ist.
+        \item Genau dann ist $A\leftrightarrow B$ eine Tautologie, wenn $A$ und $B$ unter jeder Interpretation denselben Wahrheitswert haben.
         \item Genau dann ist $A\to B$ eine Tautologie, wenn unter jeder Interpretation, unter der $A$ eine wahre Aussage ist, auch $B$ eine wahre Aussage ist. Diejenigen Interpretationen, unter denen $A$ falsch ist, spielen hierbei keine Rolle.
     \end{enumerate}
 \end{satz}
@@ -803,7 +803,7 @@ Vermöge ihrer Extension bestimmt jede Eigenschaft eine Menge. Umgekehrt bestimm
         Unter einer festen Interpretation ist $\neg A$ genau dann wahr, wenn $A$ falsch ist. Dass $\neg A$ unter allen Interpretationen wahr ist, heißt dann genau, dass $A$ unter allen Interpretationen falsch ist.
         \item Aus der Wahrheitstafel der Äquivalenz
         \[\begin{tabular}{cc|c}
-            $A$ &  $B$ & $A \leftrightarrow A$ \\
+            $A$ &  $B$ & $A \leftrightarrow B$ \\
             \hline
             w&w&w\\
             w&f&f \\
@@ -813,7 +813,7 @@ Vermöge ihrer Extension bestimmt jede Eigenschaft eine Menge. Umgekehrt bestimm
         liest man ab, dass $A\leftrightarrow B$ genau dann wahr ist, wenn $A$ und $B$ denselben Wahrheitswert haben. Also ist $A\leftrightarrow B$ genau dann eine Tautologie, wenn $A$ und $B$ unter jeder Interpretation denselben Wahrheitswert haben, was, da wir gemäß dem Bivalenzprinzip nur mit zwei Wahrheitswerten „w“ und „f“ arbeiten, gleichwertig dazu ist, dass $A$ und $B$ unter genau denselben Interpretationen wahr sind.
         \item Betrachte die Wahrheitstafel der Implikation:
         \[\begin{tabular}{cc|c}
-            $A$ &  $B$ & $A \to A$ \\
+            $A$ &  $B$ & $A \to B$ \\
             \hline
             w&w&w\\
             w&f&f \\

--- a/_02-Beweise.tex
+++ b/_02-Beweise.tex
@@ -285,7 +285,7 @@ In diesem Abschnitt seien $A,B$ stets zwei beliebige Aussagen.
 In diesem Abschnitt seien $A,B$ stets zwei beliebige Aussagen.
 
 
-\begin{axiom}[Hin- und Rückrichtung] \label{hinruck} \index{Hinrichtung} \index{Rückrichtung} \index{Äquivalenzbeweis}
+\begin{axiom}[Hin- und Rückrichtung] \label{hinruck} \index{Hinrichtung} \index{Rückrichtung} \index{Aequivalenzbeweis@Äquivalenzbeweis}
     Aus dem Vorliegen der beiden Implikationen $A\to B$ und $B\to A$ kann auf die Äquivalenz $A\leftrightarrow B$ geschlossen werden.\footnote{vgl. \cref{teilmengeneig}c)}
     \[\begin{tabular}{r}
         $A\to B$ \\
@@ -554,7 +554,7 @@ In diesem Abschnitt seien $A,B$ stets zwei beliebige Aussagen.
         & \to & \cos^2(x)& = 1-\sin^2(x) & (\text{beide Seiten quadrieren}) \\
         & \to & \cos^2(x) + \sin^2(x) &= 1
     \end{align*}
-    und letzteres ist eine wohlbekannte wahre Aussage (die manchmal als „Satz des Pythagoras“ bezeichnet wird). Jedoch ist
+    und letzteres ist eine wohlbekannte wahre Aussage (die manchmal als „Satz des Pythagoras“\footnote{\href{https://de.wikipedia.org/wiki/Pythagoras}{Pythagoras (6. Jhd. v. Chr.)}} bezeichnet wird). Jedoch ist
         \[ \cos(\pi) = -1 \neq 1 = \sqrt{1-0^2} = \sqrt{1-\sin^2(\pi)} \]
     sodass irgendetwas nicht stimmen kann. Kannst du ausmachen, wie und wo genau sich der Fehler eingeschlichen hat?
 \end{bem}
@@ -733,7 +733,7 @@ In diesem Abschnitt seien $A,B$ stets zwei beliebige Aussagen
 
 
 \begin{bem}[*]
-    Drei natürliche Zahlen $a,b,c$, für die $a^2+b^2=c^2$ gilt, heißen ein \textbf{pythagoräisches Tripel}. Also wurde gerade bewiesen, dass $(2,3,5)$ das kleinste pythagoräische Tripel ist. Nach dem berühmten \href{https://de.wikipedia.org/wiki/Gro\%C3\%9Fer_Fermatscher_Satz}{Großen Satz von Fermat} besitzt die Gleichung $a^n+b^n=c^n$ für eine natürliche Zahl $n\ge 3$ keine positive ganzzahlige Lösung.
+    Drei natürliche Zahlen $a,b,c$, für die $a^2+b^2=c^2$ gilt, heißen ein \textbf{pythagoräisches Tripel}. Also wurde gerade bewiesen, dass $(2,3,5)$ das kleinste pythagoräische Tripel ist. Nach dem berühmten \href{https://de.wikipedia.org/wiki/Gro\%C3\%9Fer_Fermatscher_Satz}{Großen Satz von Fermat}\footnote{\href{https://de.wikipedia.org/wiki/Pierre_de_Fermat}{Pierre de Fermat (1607-1665)}} besitzt die Gleichung $a^n+b^n=c^n$ für eine natürliche Zahl $n\ge 3$ keine positive ganzzahlige Lösung.
 \end{bem}
 
 
@@ -846,7 +846,7 @@ In diesem Abschnitt sei $E(x)$ stets ein einstelliges Prädikat.
 \end{bem}
 
 
-\begin{bsp}[* Satz von Euklid] \label{euklid}
+\begin{bsp}[* Satz von Euklid\footnote{\href{https://de.wikipedia.org/wiki/Euklid}{Euklid (ca. 3. Jhd. v. Chr.)}}] \label{euklid}
     Für jede natürliche Zahl $n$ gibt es eine Primzahl, die größer als $n$ ist.
 \end{bsp}
 
@@ -940,13 +940,13 @@ Diese Und-Aussage kann gemäß \cref{undbeweise} als zwei separate Aussagen beha
 
 
 \begin{bew}
-    (Eindeutigkeit): Seien $a,b$ zwei reelle Zahlen, sodass für jede reelle Zahl $x$ gilt, dass $ax=a$ und $bx=b$. Nun ist
+    (Eindeutigkeit): Seien $a,b$ zwei reelle Zahlen derart, dass für jede reelle Zahl $x$ gilt, dass $ax=a$ und $bx=b$. Nun ist
     \begin{align*}
         a & = a\cdot b & (\text{wegen der besonderen Eigenschaft von $a$}) \\
-        & = x' \cdot x  \\
-        & = x' & (\text{wegen der besonderen Eigenschaft von $x'$})
+        & = b \cdot a  \\
+        & = b & (\text{wegen der besonderen Eigenschaft von $b$})
     \end{align*}
-    (Existenz): Da für jede reelle Zahl $y$ gilt, dass $0\cdot y=0$, erfüllt die Zahl $0$ die gewünschte Eigenschaft. \qed
+    (Existenz): Da für jede reelle Zahl $x$ gilt, dass $0\cdot x=0$, erfüllt die Zahl $0$ die gewünschte Eigenschaft. \qed
 \end{bew}
 
 
@@ -1215,7 +1215,7 @@ In diesem Abschnitt seien $A,B$ stets zwei Aussagen.
             $A:=$ „Diese Aussage ist falsch.“
         \end{quote}
         Hier gilt tatsächlich $A\leftrightarrow \neg A$.
-        \item Eine weitere berühmte Situation, in der eine Aussage äquivalent zu ihrer Negation ist, ist das „Barbier-Paradoxon“, das wiederum ein Spezialfall der sogenannten \emph{Russellschen Antinomie} ist:
+        \item Eine weitere berühmte Situation, in der eine Aussage äquivalent zu ihrer Negation ist, ist das „Barbier-Paradoxon“, das wiederum ein Spezialfall der sogenannten \emph{Russellschen Antinomie}\footnote{\href{https://de.wikipedia.org/wiki/Bertrand_Russell}{Bertrand Russell 1872-1970}} ist:
         \begin{satz}
             In Sevilla lebt kein Mann, der genau denjenigen Männern Sevillas den Bart rasiert, die sich nicht selbst den Bart rasieren.
         \end{satz}
@@ -1237,7 +1237,7 @@ In diesem Abschnitt seien $A,B$ stets zwei Aussagen.
 \end{bew}
 
 
-\begin{satz}[* Russellsche\footnote{\href{https://de.wikipedia.org/wiki/Bertrand_Russell}{Bertrand Russell 1872-1970}} Antinomie] \label{russell} \index{Russellsche Antinomie}
+\begin{satz}[* Russellsche Antinomie] \label{russell} \index{Russellsche Antinomie}
     Sei $R$ ein zweistelliges Prädikat, dessen beide Variablen vom selben Typ sind. Dann gilt:
         \[ \nexists x\ \forall y:\ (R(x,y) \leftrightarrow \neg R(y,y))\]
     Mit anderen Worten: Es gibt kein Objekt $x$, sodass jedes Objekt $y$ genau dann in Relation zu $x$ stünde, wenn es nicht in Relation zu sich selbst stünde.
@@ -1324,7 +1324,7 @@ Die bisherigen Axiome bilden zusammen die sogenannte „intuitionistische“ ode
 \begin{axiom}[Satz vom ausgeschlossenen Dritten] \label{excludedmiddle} \index{tertium non datur} \index{Satz vom ausgeschlossenen Dritten}
     Es gilt:
         \[ A\lor \neg A \]
-    Dieses Prinzip heißt auch \textbf{tertium non datur}, was latein für „ein Drittes kommt nicht vor“ ist.
+    Dieses Prinzip heißt auch \textbf{tertium non datur}, was latein für „ein Drittes kommt nicht vor“ ist. Im Englischen spricht man vom ``principle of excluded middle''.
 \end{axiom}
 
 
@@ -1585,7 +1585,7 @@ Das Schreiben eines mathematischen Beweises gliedert sich grob in drei Phasen, d
 
 \begin{aufg}
     Gegeben seien die drei Vektoren des $\R^3$:
-        \[ v_1:= \begin{pmatrix} 0 \\ 1 \\ 2 \end{pmatrix},\qquad  v_2:= \begin{pmatrix} 2 \\ 1 \\ 0 \end{pmatrix},\qquad v_3:= \begin{pmatrix} 1 \\ 1 \\ 1 \end{pmatrix}\]
+        \[ v_1:= \begin{pmatrix} 1 \\ 1 \\ 2 \end{pmatrix},\qquad  v_2:= \begin{pmatrix} 2 \\ 1 \\ 0 \end{pmatrix},\qquad v_3:= \begin{pmatrix} 1 \\ 1 \\ 1 \end{pmatrix}\]
     Man beweise, dass $(v_1,v_2,v_3)$ eine Basis des $\R^3$ ist.
 \end{aufg}
 
@@ -1641,12 +1641,12 @@ Möglicherweise wirst du mit diesem Beispiel erst in einigen Wochen etwas anfang
     \end{itemize}
     Diese Phase endet, sobald ihr einen Ansatz gefunden und weiterentwickelt habt, der sich als erfolgreich herausstellt, d.h. von dem ihr euch sicher seid, dass er sich in einen wasserdichten Beweis formulieren lässt. \\[0.5em]
     Zu dem Beispiel mit der Basis im $\R^3$: Die Recherche hat ergeben, dass ich nur noch beweisen muss: Sind $a,b,c\in \R$ drei beliebige reelle Zahlen mit
-        \[ a\begin{pmatrix} 0 \\ 1 \\ 2 \end{pmatrix} + b \begin{pmatrix} 2 \\ 1 \\ 0 \end{pmatrix}+c \begin{pmatrix} 1 \\ 1 \\ 1 \end{pmatrix} = 0  \]
+        \[ a\begin{pmatrix} 1 \\ 1 \\ 2 \end{pmatrix} + b \begin{pmatrix} 2 \\ 1 \\ 0 \end{pmatrix}+c \begin{pmatrix} 1 \\ 1 \\ 1 \end{pmatrix} = 0  \]
     so muss bereits $a=b=c=0$ gelten. Da es sich um eine Gleichung im $\R^3$ handelt, kann ich sie in ein System dreier Gleichungen zerlegen:
     \[\begin{array}{ccccccc}
         a &+& 2b &+& c &=& 0 \\
         a &+& b &+& c & =& 0 \\
-        2a &+& &+ &c & =& 0
+        2a && &+ &c & =& 0
     \end{array}\]
     Dieses lineare Gleichungssystem kann ich nun einerseits mit Schulwissen, andererseits mit dem in der LA-Vorlesung präsentierten „Gauß-Algorithmus“ lösen. \\[0.5em]
     Damit ist eine vielversprechende Beweisstrategie gefunden. Auf dem Schmierblatt vergewissere ich mich nun durch ein paar Umformungen, die für nicht-eingeweihte Leser keinen Sinn ergeben müssen, dass das Gleichunssystem tatsächlich auf $a=b=c=0$ führt:
@@ -1679,7 +1679,7 @@ Möglicherweise wirst du mit diesem Beispiel erst in einigen Wochen etwas anfang
     \begin{bew}
         Aus der Vorlesung ist bekannt, dass, da der $\R^3$ ein dreidimensionaler Vektorraum ist, eine Familie dreier Vektoren im $\R^3$ genau dann eine Basis ist, wenn sie linear unabhängig ist. Demnach genügt es zu zeigen, dass $v_1,v_2,v_3$ linear unabhängig sind. \\[0.5em]
         Dazu seien $a,b,c\in \R$ drei beliebige reelle Zahlen mit
-            \[ a\begin{pmatrix} 0 \\ 1 \\ 2 \end{pmatrix} + b \begin{pmatrix} 2 \\ 1 \\ 0 \end{pmatrix}+c \begin{pmatrix} 1 \\ 1 \\ 1 \end{pmatrix} = 0  \]
+            \[ a\begin{pmatrix} 1 \\ 1 \\ 2 \end{pmatrix} + b \begin{pmatrix} 2 \\ 1 \\ 0 \end{pmatrix}+c \begin{pmatrix} 1 \\ 1 \\ 1 \end{pmatrix} = 0  \]
         Man erhält ein lineares Gleichungssystem
         \[\begin{array}{rcccccccc}
             \text{I} &&    a &+& 2b &+& c &=& 0 \\

--- a/_03-Mengen.tex
+++ b/_03-Mengen.tex
@@ -227,7 +227,7 @@ Der Begriff der Menge wurde bereits im Vortrag über Logik in \cref{mengenimlogi
 
 
 \begin{bem} \label{mengenstrukturlos}
-    Im letzten Beispiel sehen wir ganz deutlich, dass die Elemente einer Menge keiner Reihenfolge oder „Zählung“ unterliegen: Eine Menge trägt von sich aus bis auf ihre Elemente keine weitere Struktur; Fragen wie „Wie genau / Wie oft / An welcher Stelle ist $x$ in $M$ enthalten?“ kann sie also nicht beantworten, sondern nur „Ist $m$ in $M$ enthalten (oder nicht)?“.
+    Im letzten Beispiel sehen wir ganz deutlich, dass die Elemente einer Menge keiner Reihenfolge oder „Zählung“ unterliegen: Eine Menge trägt von sich aus bis auf ihre Elemente keine weitere Struktur; Fragen wie „Wie genau / Wie oft / An welcher Stelle ist $x$ in $M$ enthalten?“ kann sie also nicht beantworten, sondern nur „Ist $x$ in $M$ enthalten (oder nicht)?“.
     
     Möchte man den Elementen dennoch verschiedene „Plätze“ zuweisen, bietet sich der Begriff der „Familie“ an, der später in \cref{def:familie} eingeführt wird.
 \end{bem}
@@ -406,7 +406,7 @@ Mit dem Begriff der Familie möchten wir einer Sammlung von Objekten eine zusät
 
 
 \begin{axiom}[Gleichheit von Familien] \label{familiengleich}
-    Seien $I$ irgendeine Menge und $(a_i)_{i\in I}$ und $(b_i)_{i\in I}$ zwei durch $I$ indizierte Familien, so sind diese beiden Familien genau dann gleich, wenn sie an jedem Index denselben Eintrag besitzen. Als Formel:
+    Sind $I$ irgendeine Menge und $(a_i)_{i\in I}$ und $(b_i)_{i\in I}$ zwei durch $I$ indizierte Familien, so sind diese beiden Familien genau dann gleich, wenn sie an jedem Index denselben Eintrag besitzen. Als Formel:
     \begin{align*}
         (a_i)_{i\in I}=(b_i)_{i\in I} \qquad\leftrightarrow\qquad \forall i\in I:\ a_i=b_i
     \end{align*}
@@ -435,7 +435,7 @@ Mit dem Begriff der Familie möchten wir einer Sammlung von Objekten eine zusät
 	Dagegen hat sich die \emph{Menge} der im Raum sitzenden Leute durch den Sitzplatzwechsel nicht verändert, da immer noch dieselben Leute im Raum sitzen (nur eben an anderen Stellen). Bei $\{a_i\mid i\in I\}$ und $\{b_i \mid i\in I\}$ handelt es sich also um dieselbe Menge, während $(a_i)_{i\in I}$ und $(b_i)_{i\in I}$ zwei verschiedene Familien sind.
 	
         Hieran wird der Unterschied zwischen den Begriffen „Familie“ und „Menge“ deutlich. Zwei Mengen, in denen die gleichen Elemente vorkommen, sind nach \cref{mengengleich} schon gleich; für eine Gleichheit von Familien müssen dagegen die Elemente sich auch noch an denselben „Stellen“ befinden. Im Gegensatz zu Mengen haben Familien also eine gewisse durch die Indizierung gegebene Zusatzstruktur.\footnote{vgl. \cref{mengenstrukturlos}}
-	\item Bei Matrizen und den ``arrays'' aus aus der Informatik handelt es sich um Familien, siehe \cref{bsp:matrizen}.
+	\item Bei Matrizen und den ``arrays'' aus der Informatik handelt es sich um Familien, siehe \cref{bsp:matrizen}.
     \end{enumerate}
 \end{bsp}
 
@@ -444,13 +444,13 @@ Mit dem Begriff der Familie möchten wir einer Sammlung von Objekten eine zusät
     Seien $I,M$ zwei beliebige Mengen und $(a_i)_{i\in I}$ eine durch $I$ indizierte Familie. Ist jedes der $a_i$'s ein Element von $M$, so nennt man die Familie $(a_i)_{i\in I}$ eine \textbf{(durch $I$ indizierte) Familie mit Einträgen aus $M$} oder auch eine \textbf{$M$-wertige Familie}.
     
     Die Menge aller Familien mit Indexmenge $I$ und Einträgen aus $M$ wird mit $M^I$ notiert:
-        \[ M^I := \{ (a_i)_{i\in I} \mid \forall i\in I:\ a_i \in I \} \]
+        \[ M^I := \{ (a_i)_{i\in I} \mid \forall i\in I:\ a_i \in M \} \]
     $M^I$ heißt auch die „$I$-te Potenz von $M$“, was aber nicht mit der Potenzmenge aus \cref{def:potenzmenge} verwechselt werden sollte.
 \end{de}
 
 
 \begin{bsp}[Folgen]
-    Familien, deren Indexmenge die Menge $\N$ der natürlichen Zahlen ist, heißen \textbf{Folgen} und sind ein zentrales Thema im sechsten Vortrag.\footnote{siehe \cref{def:folge}} Beispielsweise ist $\R^\N$ die Menge derjenigen Folgen, deren Einträge allesamt reelle Zahlen sind (man spricht von \emph{reellen Folgen}). Eine solche Folge ist beispielsweise die Folge $(a_n)_{n\in\N}$ mit $a_n:=\frac{1}{n}$
+    Familien, deren Indexmenge die Menge $\N$ der natürlichen Zahlen ist, heißen \textbf{Folgen} und sind ein zentrales Thema im siebten Kapitel.\footnote{siehe \cref{def:folge}} Beispielsweise ist $\R^\N$ die Menge derjenigen Folgen, deren Einträge allesamt reelle Zahlen sind (man spricht von \emph{reellen Folgen}). Eine solche Folge ist beispielsweise die Folge $(a_n)_{n\in\N}$ mit $a_n:=\frac{1}{n}$
     \[\begin{tabular}{c|cccc}
             $n$ & 1 & 2 & 3 & $\dots$ \\ \midrule
             $a_n$ & 1 & 1/2 & 1/3 & $\dots$
@@ -478,7 +478,7 @@ Mit dem Begriff der Familie möchten wir einer Sammlung von Objekten eine zusät
     \[\begin{pmatrix}
         x \\ y \\ z 
     \end{pmatrix} \]
-    man spricht von „Vektoren“. Hier wird auch die Signifikanz des Tupelbegriffs deutlich: Beispielsweise sind $\begin{pmatrix} 2 \\ 0 \\ 3 \end{pmatrix}$ und $\begin{pmatrix} 2 \\ 3 \\ 0 \end{pmatrix}$ zwei verschiedene Vektoren, denn sie unterscheiden sich in ihrer zweiten und dritten Komponente. Dagegen sind die \emph{Mengen} $\{2,0,3\}$ und $\{0,3,2\}$ identisch\footnote{vgl. \cref{bsp:mengengleichbeweis}(b)}. Bei einer bloßen Menge gibt es keinen „zweiten Eintrag“ oder dergleichen.
+    man spricht von „Vektoren“. Hier wird auch die Signifikanz des Tupelbegriffs deutlich: Beispielsweise sind $\begin{pmatrix} 2 \\ 0 \\ 3 \end{pmatrix}$ und $\begin{pmatrix} 2 \\ 3 \\ 0 \end{pmatrix}$ zwei verschiedene Vektoren, denn sie unterscheiden sich in ihrer zweiten und dritten Komponente. Dagegen sind die \emph{Mengen} $\{2,0,3\}$ und $\{0,3,2\}$ identisch\footnote{vgl. \cref{bsp:mengengleichbeweis}}. Bei einer bloßen Menge gibt es keinen „zweiten Eintrag“ oder dergleichen.
 \end{bsp}
 
 
@@ -518,7 +518,7 @@ Mit dem Begriff der Familie möchten wir einer Sammlung von Objekten eine zusät
             M \cup N & := \{x \mid x \in M\ \text{oder}\ x \in N\} && (\text{lies: „$M$ vereinigt $N$“})
         \end{align*}
         besteht aus denjenigen Objekten, die in mindestens einer der beiden Mengen $M,N$ enthalten sind.
-        \item Die \textbf{Differenzmenge} von $M$ und $N$:
+        \item Die \textbf{Differenzmenge} von $M$ und $N$
         \begin{align*}
             M \setminus N & := \{ x \mid x \in M \ \text{und}\ x \notin N \}  && (\text{lies: „$M$ ohne $N$“})
         \end{align*}
@@ -528,7 +528,7 @@ Mit dem Begriff der Familie möchten wir einer Sammlung von Objekten eine zusät
         \begin{align*}
             N^c & := M\setminus N && (\text{sofern $N\subseteq M$})
         \end{align*}
-        und spricht vom \textbf{Komplement von $N$ (in $M$)}. Manche Autoren schreiben auch „$\calC_M(N)$“ für das Komplement von $N$ in $M$. Beachte, dass diese Schreibweise nur Sinn ergibt, wenn aus dem Kontext heraus klar ist, dass $N$ als Teilmenge von $M$ verstanden wird.
+        und spricht vom \textbf{(relativen) Komplement von $N$ (in $M$)}. Beachte, dass diese Schreibweise nur Sinn ergibt, wenn aus dem Kontext heraus klar ist, dass das Komplement in der Obermenge $M$ zu bilden ist. Manche Autoren schreiben auch „$\calC_M(N)$“ für das Komplement von $N$ in $M$.
 	\end{itemize}
     \begin{figure}[ht]
         \begin{minipage}{.48\textwidth}
@@ -666,17 +666,6 @@ Mit dem Begriff der Familie möchten wir einer Sammlung von Objekten eine zusät
         \item Es ist
             \[ \{2,3,4\}\times \{ \clubsuit,\heartsuit\} = \{ (2,\clubsuit), (3,\clubsuit), (4,\clubsuit), (2,\heartsuit), (3,\heartsuit), (4,\heartsuit) \}\]
         \item Es ist $\R\times \R=\R^2$ und die Elemente von $\R\times \R$ können als Koordinaten von Punkten in der Ebene interpretiert werden. Die Idee, Punkte mithilfe von Koordinatensystemen und geometrische Figuren als Lösungsmengen von Gleichungen zu beschreiben, wird traditionell Descartes\footnote{\href{https://de.wikipedia.org/wiki/Rene_Descartes}{René Descartes (1596-1650)}} (latinisiert: Cartesius) zugeschrieben. Daher spricht man auch vom \emph{kartesischen} Produkt.
-        \item Die Elemente von $\N\times \N$ kannst du dir als „Gitterpunkte“ vorstellen.
-        \begin{figure}[ht]
-            \begin{tikzpicture}
-                \draw[style=help lines,step=1 cm] (-2.3,-2.3) grid (1.5,1.5);
-                \begin{scope}
-                \draw[->, thick] (-2.5,-2) -- (2,-2) node[right] {$\N$};
-                \draw[->, thick] (-2,-2.5) -- (-2,2) node[above] {$\N$};
-                \end{scope}
-            \end{tikzpicture}
-        \centering \caption{Visualisierung von $\N\times \N$}
-        \end{figure}
     \end{enumerate}
 \end{bsp}
 
@@ -775,7 +764,7 @@ Mit dem Begriff der Familie möchten wir einer Sammlung von Objekten eine zusät
 
     Aber auch nicht-disjunkte Mengen können aufeinander „addiert“ werden mithilfe des folgenden Tricks: Ist $(M_i)_{i\in I}$ eine beliebige (nicht notwendig paarweise disjunkte) Mengenfamilie, so sind die Mengen
     \begin{align*}
-        \{i\}\times M_i &= \{(i,x) \mid i\in I,\ x\in M_i\} && i\in I
+        \{i\}\times M_i &= \{(i,x) \mid x\in M_i\} && i\in I
     \end{align*}
     paarweise disjunkt. Die Elemente von $\{i\}\times M_i$ kannst du dir vorstellen als die gleichen Elemente wie von $M_i$, nun aber mit einem „Marker“ versehen, der ihre Zugehörigkeit zu $M_i$ kennzeichnet und sie von den Elementen von $\{j\}\times M_j$ für $j\in I\setminus \{i\}$ unterscheidet. Durch den Übergang von $M_i$ zu den $\{i\}\times M_i$ wurden die $M_i$'s „künstlich disjunkt gemacht”. 
 \end{bem}

--- a/_04-Abbildungen.tex
+++ b/_04-Abbildungen.tex
@@ -29,7 +29,7 @@ Die folgende Abbildungsdefinition mag zu Beginn recht abstrakt und nichtssagend 
 
 
 \begin{axiom}[Gleichheit von Abbildungen] \label{abbgleich}
-    Seien $X,Y$ zwei Mengen. Zwei Abbildungen $f,g:X\to Y$ von $X$ nach $Y$ stimmen genau dann überein, wenn sie an jeder Stelle denselben Funktionswert haben. Als Formel:
+    Seien $X,Y$ zwei Mengen. Zwei Abbildungen $f,g$ von $X$ nach $Y$ stimmen genau dann überein, wenn sie an jeder Stelle denselben Funktionswert haben. Als Formel:
         \[ f=g \qquad\Leftrightarrow\qquad \forall x\in X:\ f(x)=g(x) \]
     Dementsprechend sind $f$ und $g$ genau dann voneinander verschieden, wenn es ein Element von $X$ gibt, an dem $f$ und $g$ verschiedene Funktionswerte annehmen.
     
@@ -44,7 +44,7 @@ Die folgende Abbildungsdefinition mag zu Beginn recht abstrakt und nichtssagend 
         f:X \to Y \qquad & \text{oder auch}\qquad X\xrightarrow{f} Y && (\text{lies: „$f$ von $X$ nach $Y$“})
     \end{align*}
     Definitionsbereich, Wertebereich und Graph einer Abbildung $f$ werden manchmal notiert durch
-        \[ \dom(f)\qquad, \qquad \codom(f) \qquad\text{und}\qquad \graph(f)\]
+        \[ \dom(f)\ , \qquad \codom(f) \qquad\text{und}\qquad \graph(f)\]
     Die Menge aller Abbildungen von $X$ nach $Y$ wird mit $\text{Abb}(X,Y)$ notiert:
         \[ \text{Abb}(X,Y) := \{ f \mid f\ \text{ist eine Abbildung von $X$ nach $Y$} \} \]
 \end{nota}
@@ -59,7 +59,7 @@ Die folgende Abbildungsdefinition mag zu Beginn recht abstrakt und nichtssagend 
     
     Jede solche Zuordnungsvorschrift definiert eine Abbildung $X\to Y$, deren Funktionswerte an Elementen $x\in X$ genau mit den Elementen $t(x)$ übereinstimmt. Möchte man diese Abbildung mit einer Variable bezeichnen, schreibt man:
     \begin{align*}
-        f : X\to Y \ & ,\ x\mapsto t(x) && (\text{lies: „$f$ von $X$ nach $Y$, $x$ geht auf $T(x)$“})
+        f : X\to Y \ & ,\ x\mapsto t(x) && (\text{lies: „$f$ von $X$ nach $Y$, $x$ geht auf $t(x)$“})
     \end{align*}
     Mit dieser Notation wird festgelegt, dass das Zeichen „$f$“ fortan diejenige Abbildung $X\to Y$ bezeichnen soll, die durch die Zuordnung $x\mapsto t(x)$ gegeben ist. Für jedes $x\in X$ gilt also $f(x)=t(x)$. Nach \cref{abbgleich} ist $f$ durch diese Eigenschaft eindeutig bestimmt.
 \end{nota}
@@ -95,7 +95,7 @@ Die folgende Abbildungsdefinition mag zu Beginn recht abstrakt und nichtssagend 
             \[ \Abb(-,-) : \Set \times \Set \to \Set \ ,\ (X,Y) \mapsto \Abb(X,Y) \]
         die jedem Mengenpaar $(X,Y)$ die Menge $\Abb(X,Y)$ aller Abbildungen $X\to Y$ zuordnet.
     \end{enumerate}
-    Aus der Schule bist du es vielleicht gewohnt, dass der Graph einer Funktion eine Art „Kurve“ ist. Beachte, dass unsere allgemeine Graphendefinition deutlich abstrakter ist und der Graph einer Abbildung in der Regel keine „geometrische“ Bedeutung besitzt.
+    Aus der Schule bist du es vielleicht gewohnt, dass der Graph einer Funktion eine Art „Kurve“ ist. Beachte, dass unsere allgemeine Graphendefinition deutlich abstrakter ist und der Graph einer Abbildung in der Regel keine „geometrische“ Bedeutung besitzt. Zumindest im Fall einer Abbildung $\R\to \R$ ist deren Graph zwar eine Teilmenge des $\R^2$, die im Allgemeinen aber alles Andere als „kurvig“ aussehen kann.
 \end{bsp}
 
 
@@ -143,7 +143,7 @@ Die folgende Abbildungsdefinition mag zu Beginn recht abstrakt und nichtssagend 
 
 
 \begin{bem}[Zuordnungsvorschriften vs. Abbildungen] \label{zuordvsabb}
-    Jede Zuordnungsvorschrift kann zur Definition eine Abbildung verwendet werden. Beachte, dass Zuordnungsvorschriften und Abbildungen nicht ganz dasselbe sind. Eine Zuordnungsvorschrift ist ein sprachliches Gebilde, eine konkrete Vorschrift, wie Gegenständen vom Typ $X$ Gegenstände vom Typ $Y$ zuzuordnen seien, wohingegen der Abbildungsbegriff eine mathematische Abstraktion darstellt (dies ist in \cref{def:abbildung} gemeint mit „Abstraktion einer Vorschrift“). Das Verhältnis ist ähnlich wie das zwischen Eigenschaften und Mengen, siehe \cref{mengenvseig}:
+    Jede Zuordnungsvorschrift kann zur Definition einer Abbildung verwendet werden. Beachte, dass Zuordnungsvorschriften und Abbildungen nicht ganz dasselbe sind. Eine Zuordnungsvorschrift ist ein sprachliches Gebilde, eine konkrete Vorschrift, wie Gegenständen vom Typ $X$ Gegenstände vom Typ $Y$ zuzuordnen seien, wohingegen der Abbildungsbegriff eine mathematische Abstraktion darstellt (dies ist in \cref{def:abbildung} gemeint mit „Abstraktion einer Vorschrift“). Das Verhältnis ist ähnlich wie das zwischen Eigenschaften und Mengen, siehe \cref{mengenvseig}:
     \begin{itemize}
         \item Dieselbe Abbildung kann durch verschiedene Zuordnungsvorschriften zustandekommen. Beispielsweise sind
         \begin{align*}
@@ -676,7 +676,7 @@ In diesem Abschnitt seien stets $X,Y$ zwei Mengen und $f:X\to Y$ eine Abbildung.
 
     Auf diese Weise ist es uns gelungen, $f$ „künstlich surjektiv“ zu machen. Ist uns daran gelegen, mit surjektiven Abbildungen zu arbeiten, so stellt das also kein Problem dar, da wir den Wertebereich einer Abbildung stets auf ihr Bild einschränken können.
 
-    Ebenso ist es möglich, die Abbildung $f$ „künstlich injektiv“ zu machen. Dabei besteht der Trick darin, zwischen solchen Elementen von $X$, die unter $f$ denselben Funktionswert haben, „nicht mehr zu unterscheiden“. Die Technik „ähnliche Elemente nicht mehr voneinander zu unterscheiden“ wird in der LA1 eine prominente Rolle im Umfeld des sogenannten \href{https://de.wikipedia.org/wiki/Homomorphiesatz}{Homomorphiesatzes} spielen und kann mithilfe von \emph{Äquivalenzrelationen}, die Relationen-Kapitel thematisiert werden, formalisiert werden siehe \cref{teilmengenvsfaktormengen}
+    Ebenso ist es möglich, die Abbildung $f$ „künstlich injektiv“ zu machen. Dabei besteht der Trick darin, zwischen solchen Elementen von $X$, die unter $f$ denselben Funktionswert haben, „nicht mehr zu unterscheiden“. Die Technik „ähnliche Elemente nicht mehr voneinander zu unterscheiden“ wird in der LA1 eine prominente Rolle im Umfeld des sogenannten \href{https://de.wikipedia.org/wiki/Homomorphiesatz}{Homomorphiesatzes} spielen und kann mithilfe von \emph{Äquivalenzrelationen}, die im Relationenkapitel thematisiert werden, formalisiert werden siehe \cref{teilmengenvsfaktormengen}
 \end{vorschau}
 
 
@@ -718,7 +718,7 @@ In diesem Abschnitt seien stets $X,Y$ zwei Mengen und $f:X\to Y$ eine Abbildung.
         sodass $g_k\circ f=\id_{\N_0}$ und $f\circ g_k\neq \id_{\N_0}$. Also ist zwar $f$ linksinvers zu $g_k$ (und dementsprechend $g_k$ rechtsinvers zu $f$), aber nicht rechtsinvers zu $g_k$.
         \[\begin{tikzcd}
             f\vcentcolon & 0 \ar[r, bend left]& 1 \ar[r, bend left]& 2 \ar[r, bend left]& 3 \ar[r, bend left, mapsto]& 4 \ar[r, bend left]& 5 \ar[r, bend left]& \dots \\
-            g_k\vcentcolon & 0 \ar[loop, out=145, in=215, looseness=5] & 1 \ar[l, bend right] & 2 \ar[l, bend right] & 3 \ar[l, bend right] & 4  \ar[l, bend right] & 5  \ar[l, bend right] &  \ar[l, bend right]  \dots
+            g_0\vcentcolon & 0 \ar[loop, out=145, in=215, looseness=5] & 1 \ar[l, bend right] & 2 \ar[l, bend right] & 3 \ar[l, bend right] & 4  \ar[l, bend right] & 5  \ar[l, bend right] &  \ar[l, bend right]  \dots
         \end{tikzcd}\]
         \item Die Abbildung
             \[ \Z\to \Z \ ,\ n\mapsto n+1 \]
@@ -780,7 +780,7 @@ In diesem Abschnitt seien stets $X,Y$ zwei Mengen und $f:X\to Y$ eine Abbildung.
 \end{bem}
 
 
-\begin{satz}[Bijektiv $\Leftrightarrow$ invertierbar] \label{bijektiviso}
+\begin{satz} \label{bijektiviso}
     Seien $X,Y$ zwei Mengen und $X\xrightarrow{f} Y$ eine Abbildung. Dann sind äquivalent:
     \begin{enumerate}[(i)]
         \item $f$ ist invertierbar.

--- a/_05-Relationen.tex
+++ b/_05-Relationen.tex
@@ -11,7 +11,7 @@
 \section{Allgemeines}
 
 
-Der Begriff der Relation wurde bereits im Logikkapitel in \cref{def:praedikat} eingeführt. In diesem Kapitel soll es um eine Abstraktion jenes logischen Relationsbegriff gehen.
+Der Begriff der Relation wurde bereits im Logikkapitel in \cref{def:praedikat} eingeführt. In diesem Kapitel soll es um eine Abstraktion jenes logischen Relationsbegriffs gehen.
 
 
 \begin{de}[Relation -- abstrakte Definition] \label{def:relation} \index{Relation}
@@ -134,7 +134,7 @@ Der Begriff der Relation wurde bereits im Logikkapitel in \cref{def:praedikat} e
 \end{bsp}
 
 
-\begin{bem}[* Pullback von Relationen]
+\begin{bem}[* Pullback von Relationen] \label{pullbackrel}
     Seien $X,Y$ zwei Mengen, $X\xrightarrow{f} Y$ eine Abbildung und $R$ eine Relation auf $Y$. Dann ist durch
     \begin{align*}
         a\ f^*R\ b \qquad& :\Leftrightarrow\qquad f(a)\ R\ f(b) &&a,b\in X
@@ -146,7 +146,7 @@ Der Begriff der Relation wurde bereits im Logikkapitel in \cref{def:praedikat} e
 
 
 \begin{vorschau}[* mengentheoretische Relationsdefinition]
-    Die Relationsdefinition \cref{def:relation} ist, ähnlich wie die Mengendefinition \cref{def:menge} und die Abbildungsdefinition \cref{def:abbildung} nur informell. Wenn man denn mächte, lässt sie sich aber durch eine präzise mengentheoretische Definition ersetzen:
+    Die Relationsdefinition \cref{def:relation} ist, ähnlich wie die Mengendefinition \cref{def:menge} und die Abbildungsdefinition \cref{def:abbildung} nur informell. Wenn man denn möchte, lässt sie sich aber durch eine präzise mengentheoretische Definition ersetzen:
     
     Eine Relation auf einer Menge $X$ ist eine Teilmenge $R\subseteq X\times X$. Für Elemente $x,y\in X$ definiert man dann
     \begin{align*}
@@ -252,7 +252,7 @@ Der Begriff der Relation wurde bereits im Logikkapitel in \cref{def:praedikat} e
     (Transitivität): Seien $R$ transitiv und $x,y,z\in X$ mit $xR^\op yR^\op z$. Also gilt $zRyRx$ und aus der Transitivität von $R$ ergibt sich $zRx$, also $xR^\op z$. Da $x,y,z\in X$ beliebig gewählt waren, ist damit gezeigt, dass auch $R^\op$ transitiv ist. \\[0.5em]
     (Symmetrie): Ist $R$ symmetrisch, so ist $R^\op=R$, sodass auch $R^\op$ symmetrisch ist. \\[0.5em]
     (Antisymmetrie): Seien $R$ antisymmetrisch und $x,y\in X$ mit $x R^\op y$ und $y R^\op x$. In Termen von $R$ heißt das $y Rx$ und $x Ry$, sodass sich $y=x$ aus der Antisymmetrie von $R$ ergibt. Also ist $x=y$, sodass auch $R^\op$ antisymmetrisch ist.
-    \item Bei den Definitionen von Reflexivität, Transitivität, Symmetrie und Antisymmetrie handelt es sich jeweils um Allaussagen über die Elemente von $X$. Wenn diese Aussagen für alle Elemente von $X$ gelten, so erst recht auch für alle Elemente der Teilmenge $U$.
+    \item Bei den Definitionen von Reflexivität, Transitivität, Symmetrie und Antisymmetrie handelt es sich jeweils um Allaussagen über die Elemente von $X$. Wenn diese Aussagen für alle Elemente von $X$ gelten, so erst recht auch für alle Elemente der Teilmenge $U$. \qed
     \end{enumerate}
 \end{bew}
 
@@ -302,7 +302,7 @@ Der Begriff der Relation wurde bereits im Logikkapitel in \cref{def:praedikat} e
         x < y \qquad &:\Leftrightarrow\qquad x\le y\quad \text{und}\quad y \not \le x \\
         x > y \qquad &:\Leftrightarrow\qquad y < x
     \end{align*}
-    Es ist $\ge$ und $>$ per Definition genau die Umkehrrelationen von $\le$ und $<$ im Sinne von \cref{def:umkehrrel}.
+    Es sind $\ge$ und $>$ per Definition genau die Umkehrrelationen von $\le$ und $<$ im Sinne von \cref{def:umkehrrel}.
 \end{nota}
 
 
@@ -345,7 +345,7 @@ Der Begriff der Relation wurde bereits im Logikkapitel in \cref{def:praedikat} e
         \begin{align*}
             A\le B \qquad &:\Leftrightarrow\qquad  \text{Es lässt sich beweisen, dass $A\to B$} && A,B\in \calA
         \end{align*}
-        eine Präordnung, d.h. reflexiv und transitiv. 
+        eine Präordnung, d.h. reflexiv und transitiv. Sie ist allerdings nicht antisymmetrisch und somit keine Ordnungsrelation.\footnote{Mittels Übergang zur sogenannten \emph{Lindenbaum-Algebra} kann sie allerdings künstlich antisymmetrisch gemacht werden, vgl. \cref{bsp:faktormenge}(4).}
         \begin{bew}
             (reflexiv): Die Reflexivität wurde in \cref{implikationref} bewiesen.
 
@@ -372,7 +372,7 @@ Der Begriff der Relation wurde bereits im Logikkapitel in \cref{def:praedikat} e
     \begin{enumerate}
         \item Die geordnete Menge $\{1,2,3,4,5\}$ (mit der gewöhnlichen, von $\N$ induzierten Ordnung) kann visualisiert werden durch:
         \[\begin{tikzcd}
-            1 \ar[r, dash] & 4 \ar[r, dash] & 3 \ar[r, dash] & 4 \ar[r, dash] & 5
+            1 \ar[r, dash] & 2 \ar[r, dash] & 3 \ar[r, dash] & 4 \ar[r, dash] & 5
         \end{tikzcd}\]
         \item Die geordnete Menge $(\{\{1\},\{2\},\{1,2,3\},\{1,2,4\}\},\subseteq)$ sieht folgendermaßen aus:
         \[\begin{tikzcd}
@@ -459,8 +459,8 @@ Der Begriff der Relation wurde bereits im Logikkapitel in \cref{def:praedikat} e
 \begin{de} \label{def:kleinstes} \index{größtes Element} \index{Maximum} \index{kleinstes Element} \index{Minimum} \index{maximales Element} \index{minimales Element}
 Sei $X$ eine geordnete Menge. Ein Element $a\in X$ heißt
     \begin{itemize}
-        \item \textbf{Kleinstes Element} (oder auch: \textbf{Minimum}) von $X$, falls für jedes $x\in X$ gilt, dass $a\le x$. Mit anderen Worten: „Jedes Element ist größergleich $x$“.
-        \item \textbf{Größtes Element} (oder auch: \textbf{Maximum}) von $X$, falls für jedes $x\in X$ gilt, dass $a\le x$.
+        \item \textbf{kleinstes Element} (oder auch: \textbf{Minimum}) von $X$, falls für jedes $x\in X$ gilt, dass $a\le x$. Mit anderen Worten: „Jedes Element ist größergleich $x$“.
+        \item \textbf{größtes Element} (oder auch: \textbf{Maximum}) von $X$, falls für jedes $x\in X$ gilt, dass $a\le x$.
         \item \textbf{minimales Element} von $X$, falls es kein $x\in X$ gibt, für das $x<a$ gälte. Mit anderen Worten: „Es gibt kein strikt kleineres Element“.
         \item \textbf{maximales Element} von $X$, falls es kein $x\in X$ gibt, für das $a>x$ gälte.
     \end{itemize}
@@ -482,7 +482,7 @@ Sei $X$ eine geordnete Menge. Ein Element $a\in X$ heißt
 \begin{nota}
     Dies rechtfertigt es, von \emph{dem} Minimum bzw. \emph{dem} Maximum von $X$ zu sprechen. Notation:
     \begin{align*}
-        \min(T) \qquad\text{und}\qquad \max(T)
+        \min(X) \qquad\text{und}\qquad \max(X)
     \end{align*}
     Beachte allerdings, dass ein kleinstes oder größtes Element nicht unbedingt existieren braucht.
 \end{nota}
@@ -592,7 +592,7 @@ Sei $X$ eine geordnete Menge. Ein Element $a\in X$ heißt
 \begin{bsp}
     \begin{enumerate}
         \item Weil $\N$ in $\Z$ nicht nach oben beschränkt ist, also gar keine einzige obere Schranke besitzt, besitzt $\N$ auch kein Supremum in $\Z$.
-        \item Das offene Intervall $(0,1)\subseteq \R$ besitzt $0$ als Infimum und $1$ als Supremum. Allerdings sind $0,1\notin (0,1)$. Dieses Beispiel zeigt, dass das Infimum bzw. Supremum einer Teilmenge nicht unbedingt auch ein Element von ihr braucht. Wenn doch, handelt es sich um ein Minimum bzw. Maximum im Sinne von \cref{def:kleinstes}.
+        \item Das offene Intervall $(0,1)\subseteq \R$ besitzt $0$ als Infimum und $1$ als Supremum. Allerdings sind $0,1\notin (0,1)$. Dieses Beispiel zeigt, dass das Infimum bzw. Supremum einer Teilmenge nicht unbedingt auch ein Element von ihr sein braucht. Wenn doch, handelt es sich um ein Minimum bzw. Maximum im Sinne von \cref{def:kleinstes}.
         \item Es ist $T:=\{x\in \Q \mid x^2 < 2\}$ eine beschränkte Teilmenge von $\Q$, die weder ein Supremum noch ein Infimum in $\Q$ besitzt. In $\R$ besitzt sie dagegen welche, nämlich $\sqrt{2}$ und $-\sqrt{2}$.
         \item In der geordneten Menge $(\{\{1\},\{2\},\{1,2,3\},\{1,2,4\}\},\subseteq)$, vgl. das Diagramm in \cref{bsp:hasse}, besitzt die Teilmenge $T:=\{\{1\},\{2\}\}$ kein Supremum. Zwar besitzt sie genau zwei obere Schranken, nämlich $\{1,2,3\}$ und $\{1,2,4\}$, aber da keine der beiden kleiner als die andere ist, ist keine der beiden ein Supremum von $T$.
         \item In der geordneten Menge $(\{\{1\},\{2\},\{1,2\},\{1,2,3\},\{1,2,4\}\},\subseteq)$, vgl. das Diagramm in \cref{bsp:hasse}, besitzt die Teilmenge $T:=\{\{1\},\{2\}\}$ dagegen ein Supremum, nämlich $\{0,1\}$.
@@ -603,7 +603,7 @@ Sei $X$ eine geordnete Menge. Ein Element $a\in X$ heißt
 
 
 \begin{bem}[Verallgemeinerbarkeit auf Präordnungen]
-    Eine Analyse ergibt, dass sich alle Definitionen und nahezu alle Sätze aus diesem Abschnitt über Ordnungsrelationen verallgemeinern lassen auf sogenannt \emph{prägeordnete Mengen}, d.h. Mengen mit einer reflexiven und transitiven (aber nicht unbedingt anstisymmetrischen) Relation. Die einzigen Aussagen, die im prägeordneten Fall nicht mehr gelten, sind die Eindeutigkeit kleinster und größter Elemente sowie die Eindeutigkeit von Infima und Suprema -- im Beweis für deren Eindeutigkeit ging essenziell die Antisymmetrie ein.
+    Eine Analyse ergibt, dass sich alle Definitionen und nahezu alle Sätze aus diesem Abschnitt über Ordnungsrelationen verallgemeinern lassen auf sogenannte \emph{prägeordnete Mengen}, d.h. Mengen mit einer reflexiven und transitiven (aber nicht unbedingt anstisymmetrischen) Relation. Die einzigen Aussagen, die im prägeordneten Fall nicht mehr gelten, sind die Eindeutigkeit kleinster und größter Elemente sowie die Eindeutigkeit von Infima und Suprema -- im Beweis für deren Eindeutigkeit ging essenziell die Antisymmetrie ein.
 \end{bem}
 
 
@@ -618,13 +618,13 @@ Sei $X$ eine geordnete Menge. Ein Element $a\in X$ heißt
         \[ 12\cdot 18 = 6\cdot 36 \]
     gleichbedeutend zu $216=216$, also einer Information, die eigentlich nicht der Rede wert ist.
     
-    Der springende Punkt ist hier das Vorliegen zweier verschiedener Abstraktionsebenen. Einerseits haben wir es beim Rechnen mit schlichten Zeichenketten wie „$12\cdot 18$“ oder „$6\cdot 36$“ zu tun. Auf einer abstrakteren Ebene interessieren wir uns aber eigentlich für die Zahlen, die durch die Zeichenketten \emph{repräsentiert} werden. So sind etwa „$216$“\footnote{Beachte, dass auch der Ausdruck „$216$“ noch eine Abkürzung ist für „$2\cdot 10^3 + 1\cdot 10^1 + 6 \cdot 10^0$“.} und „$12\cdot 18$“ zwei \emph{verschiedene} Zeichenketten, die dennoch \emph{dieselbe} Zahl bezeichnen. Es findet ein gedanklicher Abstraktionsprozess statt: zwei Objekte, die auf einer gewissen Ebene noch voneinander verschieden sind, fassen wir auf einer abstrakteren Ebene als identisch auf. Wir schwächen den Gleichheitsbegriff ab. Indem wir eine Gleichung „$12\cdot 18=6\cdot 36$“ als nicht-selbstverständliche Aussage hinstellen (wie hättest du darüber als Grundschüler gedacht?), machen wir auf diesen Abstraktionsprozess aufmerksam. 
+    Der springende Punkt ist hier das Vorliegen zweier verschiedener Abstraktionsebenen. Einerseits haben wir es beim Rechnen mit schlichten Zeichenketten wie „$12\cdot 18$“ oder „$6\cdot 36$“ zu tun. Auf einer abstrakteren Ebene interessieren wir uns aber eigentlich für die Zahlen, die durch die Zeichenketten \emph{repräsentiert} werden. So sind etwa „$216$“\footnote{Beachte, dass auch der Ausdruck „$216$“ noch eine Abkürzung ist für „$2\cdot 10^2 + 1\cdot 10^1 + 6 \cdot 10^0$“.} und „$12\cdot 18$“ zwei \emph{verschiedene} Zeichenketten, die dennoch \emph{dieselbe} Zahl bezeichnen. Es findet ein gedanklicher Abstraktionsprozess statt: zwei Objekte, die auf einer gewissen Ebene noch voneinander verschieden sind, fassen wir auf einer abstrakteren Ebene als identisch auf. Wir schwächen den Gleichheitsbegriff ab. Indem wir eine Gleichung „$12\cdot 18=6\cdot 36$“ als nicht-selbstverständliche Aussage hinstellen (wie hättest du darüber als Grundschüler gedacht?), machen wir auf diesen Abstraktionsprozess aufmerksam.
     
     Formalisiert werden kann dieser Prozess durch Äquivalenzrelationen. Es handelt sich dabei um alternative Gleichheitsbegriffe, die schwächer als die herkömmliche, strikte Gleichheit sind und dadurch eine „Gleihheit auf einer abstrakteren Ebene“ repräsentieren. Bisher wurden allgemeine Relationen mit dem Buchstaben $R$ und allgemeine Ordnungsrelationen mit dem Zeichen $\le$ notiert. Für allgemeine Äquivalenzrelationen nutze ich die Tilde $\sim$.
 \end{bem}
 
 
-\begin{de} \label{def:aequirel} \index{Äquivalenzrelation}
+\begin{de} \label{def:aequirel} \index{Aequivalenzrelation@Äquivalenzrelation}
     Sei $X$ eine Menge. Eine Relation $\sim$ auf $X$ heißt \textbf{Äquivalenzrelation}, wenn sie reflexiv, symmetrisch und transitiv ist. In Formeln:
     \begin{align*}
         & (\text{ÄR1}) & \forall x\in X:&&\quad & x\sim x && (\text{Reflexivität}) \\
@@ -672,7 +672,7 @@ Sei $X$ eine geordnete Menge. Ein Element $a\in X$ heißt
     \begin{align*}
         a \sim_f b \qquad&:\Leftrightarrow\qquad f(a)=f(b) && a,b\in X
     \end{align*}
-    definierte Relation eine Äquivalenzrelation auf $X$. Stellen wir uns $f$ als eine Abbildung vor, die den Elementen von $X$ gewisse „Merkmale“ zuordnet, so formalisiert die Relation $\sim_f$ das Teilen eines gemeinsamen Merkmals.
+    definierte Relation eine Äquivalenzrelation auf $X$.\footnote{Es handelt sich um den Pullback der Gleichheitsrelation entlang $f$, vgl. \cref{pullbackrel}} Stellen wir uns $f$ als eine Abbildung vor, die den Elementen von $X$ gewisse „Merkmale“ zuordnet, so formalisiert die Relation $\sim_f$ das Teilen eines gemeinsamen Merkmals.
 \end{bem}
 
 
@@ -698,7 +698,7 @@ Sei $X$ eine geordnete Menge. Ein Element $a\in X$ heißt
 \end{bsp}
 
 
-\begin{de}[Äquivalenzklasse] \label{def:aequiklasse} \index{Äquivalenzklasse} \index{Vertreter} \index{Repräsentant}
+\begin{de}[Äquivalenzklasse] \label{def:aequiklasse} \index{Aequivalenzklasse@Äquivalenzklasse} \index{Vertreter} \index{Repräsentant}
     Seien $X$ eine Menge, $\sim$ eine Äquivalenzrelation auf $X$ und $x\in X$ ein Element. Die Menge aller „zu $x$ äquivalenten“ Elemente
         \[ [x] := \{ y\in X \mid y\sim x \}\]
     heißt die \textbf{Äquivalenzklasse\footnote{Vielleicht ist dir bekannt, dass in der axiomatischen Mengenlehre zwischen „Mengen“ und „Klassen“ unterschieden wird. Die Terminologie „Äquivalenz\emph{klasse}“ hat damit allerdings nichts zu tun und ist schlicht historisch erwachsen.} von $x$}. Vor allem in der Algebra wird die Äquivalenzklasse auch mit einem Oberstrich notiert:
@@ -723,7 +723,7 @@ Sei $X$ eine geordnete Menge. Ein Element $a\in X$ heißt
 
 \begin{bsp}[*] \quad
     \begin{enumerate}
-        \item Sei $F$ die Menge der Fußballspieler in der Bundesliga. Hinsichtlich der Äquivalenzrelation „spielt im selben Verein wie“ bildet die Menge aller Mannschaftskapitäne der Bundeligavereine ein Vertretersystem, da jede jede Fußballmannschaft genau einen Mannschaftskapitän hat. Weitere Vertretersysteme erhielte man beispielsweise, indem man aus jeder Mannschaft den ältesten Spieler oder den Stammtorwart auswählt.
+        \item Sei $F$ die Menge der Fußballspieler in der Bundesliga. Hinsichtlich der Äquivalenzrelation „spielt im selben Verein wie“ bildet die Menge aller Mannschaftskapitäne der Bundeligavereine ein Vertretersystem, da jede Fußballmannschaft genau einen Mannschaftskapitän hat. Weitere Vertretersysteme erhielte man beispielsweise, indem man aus jeder Mannschaft den ältesten Spieler oder den Stammtorwart auswählt.
         \item Nach \cref{merkmal} ist auf $\Z$ durch die Relation
         \begin{align*}
             n\sim m\qquad&:\Leftrightarrow\qquad \vert n\vert=\vert m\vert && n,m\in \Z
@@ -745,7 +745,7 @@ Sei $X$ eine geordnete Menge. Ein Element $a\in X$ heißt
 \subsection*{Die Faktormenge zu einer Äquivalenzrelation}
 
 
-Äquivalenzklassen sind vergröberte, alternative Gleichheitsbegriffe. In diesem Abschnitt wird die Methode vorgestellt, vormals „äquivalente“ Elemente nun künstlich \emph{gleich} zu machen.
+Äquivalenzrelationen sind vergröberte Gleichheitsbegriffe. In diesem Abschnitt wird die Methode vorgestellt, vormals „äquivalente“ Elemente nun künstlich \emph{gleich} zu machen.
 
 
 \begin{de}[Faktormenge zu einer Äquivalenzrelation] \label{def:faktormenge} \index{Faktormenge} \index{Quotientenmenge} \index{Projektion (auf eine Faktormenge)}
@@ -771,7 +771,7 @@ Sei $X$ eine geordnete Menge. Ein Element $a\in X$ heißt
     \begin{enumerate}
         \item Sei $F$ die Menge aller Fußballspieler in der Bundesliga. Die Elemente der Faktormenge $F/{\sim}$ hinsichtlich der Äquivalenzrelation „spielt im selben Verein wie“ sind genau die Vereinskader der einzelnen Bundesligisten. Die kanonische Projektion bildet jeden Spieler $f\in F$ auf die Menge seiner Mitspieler $\{g\in F\mid g\ \text{spielt im gleichen Verein wie $f$}\}$ ab.
         \item Sei $M$ die Menge aller Menschen mit genau einer Wohnung. Die Elemente der Faktormenge $M/{\sim}$ hinsichtlich der Äquivalenzrelation „wohnt zusammen mit” sind genau die Wohngemeinschaften, d.h. die Mengen von Leuten, die sich eine gemeinsame Wohnung teilen. Die kanonische Projektion bildet eine Person ab auf die Menge aller ihrer Mitbewohner (einschließlich ihrer selbst).
-        \item Sei $n\in \N$. Die Faktormenge von $\Z$ hinsichtlich Kongruenz modulo $n$ wird notiert durch
+        \item Sei $n\in \N_{\ge 1}$. Die Faktormenge von $\Z$ hinsichtlich Kongruenz modulo $n$ wird notiert durch
         \begin{align*}
             \Z/n\Z && (\text{lies: „$\Z$ modulo $n\Z$”})
         \end{align*}

--- a/_06-Verknuepfungen.tex
+++ b/_06-Verknuepfungen.tex
@@ -291,12 +291,12 @@
         & = b*d*c*a && (\text{Kommutativgesetz für $c*a$ und $b*d$}) \\
         & \text{usw.}
     \end{align*}
-    Bei kommutativen Monoiden brauchst du also weder aufs Klammernsetzen, noch auf die Reihenfolge, in der du die Elemente verknüpfst, achten.
+    Bei Verknüpfungen, die sowohl assoziativ als auch kommutativ sind, brauchst du also weder aufs Klammernsetzen, noch auf die Reihenfolge, in der du die Elemente verknüpfst, achten.
 \end{bem}
 
 
 \begin{de}[Inverse Elemente] \label{def:inverse} \index{inverses Element} \index{Einheit (bei einer Verknüpfung)}
-    Sei $X$ eine Menge mit einer zweistelligen Verknüpfung $*$, die ein (nach \cref{neutreind} automatisch eindeutig bestimmtes) neutrales Element $e$ besitzt. Ein Element $b\in M$ heißt \textbf{invers} zu $a$, falls es die folgenden beiden „Inversengleichungen“ erfüllt:
+    Sei $X$ eine Menge mit einer zweistelligen Verknüpfung $*$, die ein (nach \cref{neutreind} automatisch eindeutig bestimmtes) neutrales Element $e$ besitzt und sei $a\in X$. Ein Element $b\in X$ heißt \textbf{invers} zu $a$, falls es die folgenden beiden „Inversengleichungen“ erfüllt:
     \begin{align*}
         a*b & = e && (\text{„$b$ ist rechtsinvers zu $a$“}) \\
         b*a & = e && (\text{„$b$ ist linksinvers zu $a$“})
@@ -352,7 +352,7 @@
 \end{bsp}
 
 
-\begin{satz}[Eindeutig inverser Elemente] \label{inveind}
+\begin{satz}[Eindeutigkeit inverser Elemente] \label{inveind}
     Seien $(M,*)$ ein Monoid und $a\in M$ ein invertierbares Element. Dann ist das inverse Element von $a$ eindeutig bestimmt.\footnote{vgl. \cref{umkehreind}}
 \end{satz}
  
@@ -393,7 +393,7 @@
         \item Das neutrale Element ist invertierbar und es gilt $e^\inv = e$.\footnote{Elemente, die invers zu sich selbst sind, heißen \textbf{selbstinvers} oder auch \textbf{Involutionen}.}
         \item(Inverses vom Inversen) Ist $a\in M$ ein invertierbares Element, so ist auch $a^\inv$ invertierbar und es ist
             \[(a^\inv)^\inv = a \]
-        \item(Regel von Hemd und Jacke) Sind $a,b\in M$ zwei invertierbare Element, so ist auch $a*b$ invertierbar und es gilt:
+        \item(Regel von Hemd und Jacke) Sind $a,b\in M$ zwei invertierbare Elemente, so ist auch $a*b$ invertierbar und es gilt:
             \[ (a*b)^\inv = b^\inv * a^\inv \]
     \end{enumerate}
 \end{satz}
@@ -433,7 +433,7 @@
 \section{Mehr Notation}
 
 
-\begin{nota}[additive und multiplikative Notation]
+\begin{nota}[additive und multiplikative Notation] \index{Summand} \index{Faktor}
     Zur Notation von Verknüpfungen gibt es zwei häufig vorkommende Schemata:
     \begin{itemize}
         \item Eine \textbf{additiv geschriebene Verknüpfung} ist eine Verknüpfung, die mit dem Zeichen „$+$“ notiert wird. Im Ausdruck
@@ -493,12 +493,12 @@
 \end{bem}
 
 
-\begin{de}[* Potenzen] \label{def:potenz} \index{Potenz}
+\begin{de}[* Potenzen] \label{def:potenz} \index{Potenz} \index{Exponent}
     Seien $M$ eine Menge mit einer assoziativen Verknüpfung $*$ und $a\in M$ irgendein Element. Für ein $n\in \N_{\ge 1}$ heißt das Element, das durch $n$-faches Verknüpfen von $a$ mit sich selbst entsteht
     \[ a^n := \underbrace{a * \ldots * a}_{n\text{-mal}} \]
     die \textbf{$n$-te Potenz von $a$}. Dabei heißen $a$ die \textbf{Basis} und $n$ der \textbf{Exponent}. Manchmal wird auch das Verknüpfungszeichen mit in den Exponenten geschrieben:
             \[ a^{*n} := \underbrace{a * \ldots * a}_{n\text{-mal}} \]
-    Sofern $M$ auch ein neutrales Element enthält, setzt man die nullte Potenz auf ebendieses:\footnote{Damit ist vom algebraischem Standpunkt auch die Frage nach dem Wert von „\href{https://en.wikipedia.org/wiki/Zero_to_the_power_of_zero}{Null hoch Null}“ beantwortet. In $\C,\R,\Q,\Z,\N_0$ gilt nach der allgemeinen Definition, dass $0^0=1$, da die Eins das neutrale Element zur Multiplikation ist.}
+    Sofern $M$ auch ein neutrales Element $e$ enthält, setzt man die nullte Potenz auf ebendieses:\footnote{Damit ist vom algebraischem Standpunkt auch die Frage nach dem Wert von „\href{https://en.wikipedia.org/wiki/Zero_to_the_power_of_zero}{Null hoch Null}“ beantwortet. In $\C,\R,\Q,\Z,\N_0$ gilt nach der allgemeinen Definition, dass $0^0=1$, da die Eins das neutrale Element zur Multiplikation ist.}
         \[ a^0 := e \]
     Ist überdies auch noch $a$ ein invertierbares Element, so lassen sich auch negative Potenzen definieren. Für $n\in \Z$ ist dann die $n$-te Potenz von $a$ definiert durch:
     \begin{align*}
@@ -513,7 +513,7 @@
 
     
 \begin{nota}[Notation im additiven Fall]
-    In additiv geschriebenen Fall wird jedoch eine andere Notation verwendet. Sei $+$ eine additiv geschriebene, assoziative Verknüpfung auf der Menge $M$. Für $a\in M$ und $n\in \N_{\ge 0}$ wird dann die $n$-te Potenz von $a$ notiert durch
+    Im additiv geschriebenen Fall wird jedoch eine andere Notation verwendet. Sei $+$ eine additiv geschriebene, assoziative Verknüpfung auf der Menge $M$. Für $a\in M$ und $n\in \N_{\ge 0}$ wird dann die $n$-te Potenz von $a$ notiert durch
         \[ n \cdot a := \underbrace{a + \ldots + a}_{n\text{-mal}} \]
     Man spricht auch vom \textbf{$n$-fachen von $a$}. Sofern $M$ ein Nullelement enthält, ist
         \[ 0\cdot a := 0_M \]
@@ -621,9 +621,9 @@ durchgeführt werden.
     \end{align*}
     Man spricht von der \textbf{leeren Summe} und vom \textbf{leeren Produkt}.
     
-    Ist überdies $M$ ein \emph{kommutatives} Monoid, so können Mehrfach-Produkte über beliebige endliche Teilmengen gebildet werden: Ist $E\subseteq M$ eine Teilmenge, die nur endlich viele Elemente enthält, so bezeichnet
-        \[ \mathop{\raisebox{-0.6ex}{\scalebox{2.5}{$*$}}}_{a\in E} a \qquad\text{bzw. im additiven Fall:}\quad \sum_{a\in E} a \qquad\text{bzw. im multiplikativen Fall:}\quad \prod_{a\in E} a\]
-    die Verknüpfung der Elemente aus $E$ in einer beliebigen (irrelevanten, da $*$ kommutativ ist) Reihenfolge.
+    Ist überdies $M$ ein \emph{kommutatives} Monoid, so können Mehrfach-Produkte über beliebige Familien mit endlichen Indexmengen gebildet werden: Ist $I$ eine Menge, die nur endlich viele Elemente enthält, und ist $(a_i)_{i\in I}$ eine durch $I$ indizierte Familie von Elementen aus $M$, so bezeichnet
+        \[ \mathop{\raisebox{-0.6ex}{\scalebox{2.5}{$*$}}}_{i\in I} a_i \qquad\text{bzw. im additiven Fall:}\quad \sum_{i\in I} a_i \qquad\text{bzw. im multiplikativen Fall:}\quad \prod_{i\in I} a_i\]
+    die Verknüpfung der $a_i$'s in einer beliebigen (irrelevanten, da $*$ kommutativ ist) Reihenfolge.
 \end{nota}
 
 
@@ -632,9 +632,10 @@ durchgeführt werden.
         \item(Binomischer Lehrsatz)\footnote{\href{https://www.youtube.com/watch?v=dQw4w9WgXcQ}{Francesco Binomi (1369-1420)}} Für $x,y,n\in \N$ gilt:
             \[ (x+y)^n = \sum_{k=0}^n \binom{n}{k} x^k\cdot y^{n-k} \]
         wobei der \emph{Binomialkoeefizient} $\binom{n}{k}$ die Anzahl aller Möglichkeiten, aus $n$-vielen Gegenständen ohne Berücksichtigung der Reihenfolge genau $k$-viele auszuwählen, bezeichnet. Im Spezialfall $n=2$ ergibt dies die aus der Schule bekannte binomische Formel $(x+y)^2=x^2+2xy+y^2$.
-        \item (Wallissches Produkt)\footnote{\href{https://de.wikipedia.org/wiki/John_Wallis}{John Wallis (1616-1703)}} Lässt man im Produkt
-            \[ \prod_{k=1}^n \frac{4k^2}{4k^2-1} = \frac{2}{1} \cdot \frac{2}{3} \cdot \frac{4}{3} \cdot \frac{4}{5} \cdot \frac{6}{5} \cdot \frac{6}{7} \cdot \frac{8}{7} \cdot \frac{8}{9} \cdot \ldots \cdot \frac{2n}{2n-1} \cdot \frac{2n}{2n+1}\]
-        die Obergrenze $n$ immer weiter ansteigen, nähert sich das Produkt der Zahl $\pi/2$ an.
+        \item Die Notation für Mehrfachprodukte kennst du bereits aus dem Mengenkapitel, wo sie für Durchschnitte, (disjunkte) Vereinigungen und Produkte von Mengen angesprochen wurde, siehe etwa \cref{alternativmehrfachcapcup}.
+        \item(„Unendliche“ Mehrfachprodukte?) In der Welt der zweistelligen Verknüpfungen, also dieses Kapitels, ist es nicht ohne Weiteres möglich, auch Verknüpfungen unendlich vieler Elemente zugleich zu definieren. Dies wäre auf die Anwesenheit von Zusatzstruktur, etwa einer sogenannten \emph{Topologie}, angewiesen. Schon in der Ana1 können damit „unendliche Summen“ studiert werden. Beispielsweise gilt für jede reelle Zahl $q\in \R$ mit $\vert q\vert < 1$:\footnote{vgl. \cref{aufg:geometrischereihe}}
+            \[ \sum_{k=0}^\infty q^k = 1 + q + q^2 + q^3 + \ldots = \frac{1}{1-q} \]
+        Der Ausdruck „$\sum_{k=0}^\infty$“ ist allein durch die Werkzeuge aus diesem Kapitel \emph{nicht} wohldefiniert, sondern muss in der Sprache der Analysis verstanden werden. Kannst du dir die Gleichung für den Fall $q=\frac{1}{2}$ intuitiv erklären?
     \end{enumerate}
 \end{bsp}
 
@@ -786,17 +787,20 @@ durchgeführt werden.
 \end{comment}
 
 
-\begin{aufg}[Rechenregeln für Mehrfach-Summen] \index{Indexshift} \index{Teleskopsumme}
-    Seien $(M,+)$ ein kommutatives Monoid, $n,m\in \N_{\ge 1}$ zwei natürliche Zahlen, $a_1,\dots , a_n \in M$ und $(a_{ij})\in M^{n\times m}$. Vollzieht die folgenden Gleichungen nach:
-    \begin{align*}
-        \text{a)} && \sum_{k=1}^n a_k & = \sum_{k=0}^{n-1} a_{k+1} && (\text{Indexshift}) \\
-        \text{b)} && \sum_{k=1}^{n-1} (a_{k+1} - a_k) & = a_n - a_1 && (\text{Teleskopsumme}) \\
-        \text{c)} && \sum_{i=1}^n \sum_{j=1}^m a_{ij} & = \sum_{j=1}^m \sum_{i=1}^n a_{ij} && (\text{Vertauschen von Doppelsummen})
-    \end{align*}
+\begin{aufg}[Geometrische Reihe] \label{aufg:geometrischereihe}
+    Vollzieht den Beweis des folgenden Satzes nach. Ist der Beweis korrekt und vollständig? Stimmt der Satz überhaupt?
+    \begin{satz}
+        Für alle $n\in \N$ und $q\in \R$ gilt:
+            \[ (1-q) \cdot \sum_{k=0}^n q^k = 1-q^{n+1} \]
+    \end{satz}
+    \begin{bew}
+        Es gilt:
+        \begin{align*}
+            (1-q) \cdot \sum_{k=0}^n q^k & = \left( \sum_{k=0}^n q^k \right) - \left( \sum_{k=1}^{n+1} q^{k} \right) \\
+            & = \left( \sum_{k=0}^n q^k \right) - \left( \sum_{k=0}^{n} q^{k+1} \right) && (\text{„Indexshift“}) \\
+            & = \sum_{k=0}^n (q^k - q^{k+1}) \\
+            & = 1 - q^{n+1} && (\text{„Teleskopsumme“}) \qed
+        \end{align*}
+    \end{bew}
 \end{aufg}
 
-
-\begin{aufg}[Geometrische Reihe]
-    Seien $n\in \N$ und $q\in \R$. Beweist die folgende Gleichung:
-        \[ (1-q) \cdot \sum_{k=0}^n q^n = 1-q^{n+1} \]
-\end{aufg}

--- a/_07-Analysis.tex
+++ b/_07-Analysis.tex
@@ -82,7 +82,7 @@
         \begin{align*}
             -\infty \le  x \le \infty && (\text{für alle $x\in \bar \R$})
         \end{align*}
-    d.h. „$-\infty$“ sei per Definition kleiner als jede reelle Zahl, „$\infty$“ dagegen größer als jede reelle Zahl. Es lässt sich zeigen, dass $(\bar \R,\le)$ auf diese Weise zu einer totalgeordneten Menge wird. Beachte, dass $\pm \infty$ keine reellen Zahlen sind und dass sich mit den Elementen von $\bar\R$ auch nur eingeschränkt rechnen lässt.
+    d.h. „$-\infty$“ sei per Definition kleiner als jede reelle Zahl, „$\infty$“ dagegen größer als jede reelle Zahl. Es lässt sich zeigen, dass $(\bar \R,\le)$ auf diese Weise zu einer totalgeordneten Menge wird. Beachte, dass $\pm \infty$ keine reellen Zahlen sind und dass sich damit auch nur eingeschränkt rechnen lässt.
 \end{de}
 
 
@@ -148,7 +148,7 @@
 \begin{bem}[Abstand im euklidischen Raum]
     Die reellen Zahlen $\R$ werden meist in der „Gestalt“ einer Gerade, der sogenannten \emph{Zahlengerade}, visualisiert. Ebenso kann der $\R^2$ als Menge von Punkten in einer Ebene, der $\R^3$ als Menge von Punkten im Raum vorgestellt werden, wobei für ein Tripel $(x,y,z)\in \R^3$ die Zahlen $x,y,z\in \R$ als Koordinaten hinsichtlich eines fixierten Koordinatensystems verstanden werden.
     
-    Obwohl es sich bei reellen Zahlen und Vektoren eigentlich um algebraische Objekte handelt, die addiert und vervielfacht werden können, erlaubt es die geometrische Interpretation, sie als „Punkte in einem Raum“ aufzufassen. Zwischen je zwei Punkten auf einer Gerade, in der Ebene oder im Raum kann die Verbindungsgerade gezogen werden. Die Länge dieser Verbindungsgerade gibt den \emph{Abstand} der beiden Punkte voneinander an. Der Begriff des Abstands liefert einen von vielen Zugängen zu den Konzepten \emph{Stetigkeit} und \emph{Konvergenz}, der in diesem Kapitel beschritten wird.
+    Obwohl es sich bei reellen Zahlen und Vektoren eigentlich um algebraische Objekte handelt, die addiert und vervielfacht werden können, erlaubt es die geometrische Interpretation, sie als „Punkte in einem Raum“ aufzufassen. Zwischen je zwei Punkten auf einer Gerade, in der Ebene oder im Raum kann die Verbindungsstrecke gezogen werden. Die Länge dieser Verbindungsstrecke gibt den \emph{Abstand} der beiden Punkte voneinander an. Der Begriff des Abstands liefert einen von vielen Zugängen zu den Konzepten \emph{Stetigkeit} und \emph{Konvergenz}, der in diesem Kapitel beschritten wird.
     
     Auf der Geraden $\R$, der Ebene $\R^2$ und im Raum $\R^3$ ist der Abstandsbegriff sekundär, indem er als Länge eines Verbindungsvektors definiert wird. Eine direkte Axiomatisierung des Abstandsbegriffs, die auf keinerlei weitere Zusatzstruktur angewiesen ist, geht folgendermaßen:
 \end{bem}
@@ -204,7 +204,7 @@
 \begin{bsp}[Weitere Metriken] \quad
     \begin{enumerate}
         \item(Ebene und räumliche Abstände) In der Ebene $\R^2$, im Raum $\R^3$ und allgemein im Hyperraum $\R^n$ (für ein $n\in \N$) ist der Abstand zweier Punkte gleich der Länge ihrer Verbindungsstrecke. Dies wird in den Analysis-Vorlesungen genauer definiert werden.\footnote{Mehr darüber findest du in \cite{AE06} in Kapitel II.3.} Ich gehe davon aus, dass dir intuitiv klar ist, wie der Abstand zwischen zwei Punkten in der Ebene oder im Raum zu verstehen ist und werde es ab und zu in einem informellen Sinn nutzen, um mehrdimensionale Beispiele und Illustrationen beisteuern zu können.
-        \item(Topologische Datenanalyse) Manchmal können die „Punkte“ eines metrischen Raums auch als „Daten“ verstanden werden. Beispielsweise wäre ein metrischer Raum $X$ gegeben durch die Menge der Nutzer einer Dating-App, die bei ihrer Anmeldung verschiedene persönliche Vorlieben und Eigenschaften angegeben haben. Für zwei Nutzer $a,b\in X$ könnte dann der „Abstand“ $d(a,b)$ definiert sein als die Anzahl aller Kategorien, in denen $a$ und $b$ verschiedene Präferenzen angegeben haben. Nutzer mit vielen gemeinsamen Interessen wären sich bezüglich dieser Metrik also besonders „nahe“.
+        \item(Topologische Datenanalyse) Nicht immer müssen die „Punkte“ eines metrischen Raums eine geometrische Bedeutung besitzen. Beispielsweise wäre ein metrischer Raum $X$ gegeben durch die Menge der Nutzer einer Dating-App, die bei ihrer Anmeldung verschiedene persönliche Vorlieben und Eigenschaften angegeben haben. Für zwei Nutzer $a,b\in X$ könnte dann der „Abstand“ $d(a,b)$ definiert sein als die Anzahl aller Kategorien, in denen $a$ und $b$ verschiedene Präferenzen angegeben haben. Nutzer mit vielen gemeinsamen Interessen wären sich bezüglich dieser Metrik also besonders „nahe“.
     \end{enumerate}
 \end{bsp}
 
@@ -278,7 +278,7 @@
 \begin{bem}[Intuition]
     Die Ansicht, einen „Raum“ wie etwa den euklidischen dreidimensionalen Raum als eine „Punktmenge“ aufzufassen, ist vergleichsweise jung und trug wesentlich zur Entstehung des Mengenbegriffs von Cantor bei. Vormals waren der Raum oder die reelle Gerade eher als eine Art „Kontinuum“ verstanden, auf dem zwar einzelne Punkte ausgezeichnet werden können, das aber eine über die Ansammlung von Punkten hinausgehende Qualität der „Kontinuierlichkeit“ besitzt. Auch über die physikalische Realität des Punktbegriffs, eines ausdehnungslosen Orts im Raum oder in der Zeit, lässt sich streiten.\footnote{Mit einer Formalisierung von Nähe und Abweichung, die unabhängig vom Vorhandensein von Punkten ist, beschäftigt sich die \href{https://en.wikipedia.org/wiki/Pointless_topology}{punktfreie Topologie}, die bislang aber noch keinen Einzug in den mathematischen Mainstream gefunden hat.}
     
-    In Physik und Stochastik können meist nur Näherungsbereiche für einen Punkt angegeben werden. Beispielsweise ist die Wahrscheinlichkeit dafür, dass ein Dartspieler exakt die Mitte des Dartboards trifft, exakt $0{,}0\%$, da es sich bei der „Mitte des Boards“ um eine mathematische Idealisierung handelt. Dagegen kann für das Treffen des etwa 1cm breiten Bullseye durchaus eine positive Wahrscheinlichkeit angegeben werden, die bei einem professionellen Spieler wie zum Beispiel ``The Power'' durchaus im zweistelligen \%-Bereich liegt.
+    In Physik und Stochastik können meist nur Näherungsbereiche für einen Punkt angegeben werden. Beispielsweise ist die Wahrscheinlichkeit dafür, dass ein Dartspieler exakt die Mitte des Dartboards trifft, exakt $0{,}0\%$, da es sich bei der „Mitte des Boards“ um eine mathematische Idealisierung handelt. Dagegen kann für das Treffen des etwa 1cm breiten Bullseye durchaus eine positive Wahrscheinlichkeit angegeben werden, die bei einem professionellen Spieler wie zum Beispiel Phil ``The Power'' Taylor durchaus im zweistelligen \%-Bereich liegt.
     
     Beim Bullseye-Feld handelt es sich um eine „Umgebung“ des Board-Mittelpunkts. Per Definition beinhaltet eine Umgebung $U$ eines Punkts $a$ einen $\varepsilon$-Ball. Der Punkt hat also einen gewissen „Puffer“ um sich herum in $U$. Sofern wir den Punkt $a$ nur bis auf eine Genauigkeit in der Größe von $\varepsilon$ verorten können, kann dennoch garantiert werden, dass $U$ den Punkt $a$ enthält.
 \end{bem}
@@ -350,7 +350,7 @@
     Hier ist noch ein Beispiel für eine Folge, deren Einträge mal keine Zahlen sind:
     \begin{enumerate}[(9)]
         \item Die Folge $(\{1,\dots , n\})_{n\in \N_0}$, deren Einträge die „Anfangsstücke“ von $\N_{\ge 1}$ sind. Also
-            \[ \emptyset,\quad \{1\},\quad \{1,2\},\quad \{1,2,3\},\quad \{1,2,3,4\}\quad,\dots \]
+            \[ \emptyset\ ,\quad \{1\}\ ,\quad \{1,2\}\ ,\quad \{1,2,3\}\ ,\quad \{1,2,3,4\}\ , \quad \dots \]
         Dies ist keine Zahlenfolge, sondern eine Folge von Mengen. Sie besitzt die Eigenschaft, dass für jedes $n\in \N_0$ ihr $n$-ter Eintrag eine Menge ist, die genau $n$-viele Elemente enthält.
     \end{enumerate}
     Eine riesige Datenbank ganzzahliger Zahlenfolgen ist die \href{https://oeis.org/}{On-Line Encyclopedia of Integer Sequences}.
@@ -429,7 +429,7 @@ Es gilt:
             \[ 0,\quad -1,\quad -2,\quad -1,\quad 0,\quad 1,\quad 2,\quad 3,\quad 4, \quad 5,\dots \]
         ist nicht monoton. Sie könnte aber zu einer strikt wachsenden Folge gemacht werden, ließe man die ersten zwei Folgenglieder weg. Somit ist sie „wachsend für hinreichend große $n$“.
         \item Die alternierende Folge $((-1)^n)_{n\in \N}$ ist dagegen nicht einmal für hinreichend große $n$ wachsend, denn egal wie spät wir auch einsteigen, das Rauf und Runter hört nie auf.
-        \item Ist $\varepsilon \in \R_{>0}$ eine (unter Umständen winzig kleine) positive reelle Zahl, so sind die Einträge Folge $\left(\frac{1}{n}\right)_{n\in \N}$ dennoch für hinreichend große $n$ (um genau zu sein für $n> \frac{1}{\varepsilon}$) kleiner als $\varepsilon$. Mit anderen Worten: Die Brüche $\frac{1}{n}$ werden „für hinreichend große $n$ beliebig klein“.
+        \item Ist $\varepsilon \in \R_{>0}$ eine (unter Umständen winzig kleine) positive reelle Zahl, so sind die Einträge der Folge $\left(\frac{1}{n}\right)_{n\in \N}$ dennoch für hinreichend große $n$ (um genau zu sein für $n> \frac{1}{\varepsilon}$) kleiner als $\varepsilon$. Mit anderen Worten: Die Brüche $\frac{1}{n}$ werden „für hinreichend große $n$ beliebig klein“.
     \end{enumerate}
 \end{bsp}
 
@@ -454,7 +454,7 @@ Es gilt:
     \end{align*}
     definieren, aber das soll gerade keine Rolle spielen.
     
-    Du siehst, dass die Folgenglieder dem Koordinatenursprung immer näher kommen, dass sie „für hinreichend großes $n$ nahe kommen“. Genau das heißt Konvergenz.
+    Du siehst, dass die Folgenglieder dem Koordinatenursprung immer näher kommen, dass sie „für hinreichend große $n$ beliebig nahe kommen“. Genau das heißt Konvergenz.
 \end{bem}
 
 
@@ -499,7 +499,7 @@ Es gilt:
 
 \begin{figure}[ht]
     \includegraphics[width=14cm]{./_img/Konvergenzbsp.jpeg}
-    \centering \caption{Eine konvergente Folge von Punkten in der Ebene}
+    \centering \caption{Die Folge $\left(\frac{n}{n+1}\right)_{n\in \N}$ konvergiert gegen $1$.}
 \end{figure}
 
 
@@ -528,7 +528,7 @@ Es gilt:
 
 
 \begin{bew}
-    Es sei $\varepsilon \in \R_{>0}$ beliebig. Sei $N\in \N$ die irgendeine natürliche Zahl, die größer als $1/\varepsilon$ ist. Für alle $n\in \N_{\ge N}$ gilt dann:
+    Es sei $\varepsilon \in \R_{>0}$ beliebig. Sei $N\in \N$ irgendeine natürliche Zahl, die größer als $1/\varepsilon$ ist. Für alle $n\in \N_{\ge N}$ gilt dann:
     \begingroup
     \allowdisplaybreaks
     \begin{align*}

--- a/_08-Anhang.tex
+++ b/_08-Anhang.tex
@@ -1,6 +1,6 @@
 
 
-\chapter{Formelsammlung Logik und Mengenlehre} \label{formelsammlung}
+\chapter{Formelsammlung Logik und Mengen} \label{formelsammlung}
 
 
 \section{Einige Aussagenlogische Tautologien}
@@ -40,10 +40,6 @@ Es gilt:
         A \to B & \quad\leftrightarrow\quad (A \land B) \leftrightarrow A \\
         A \to B & \quad\leftrightarrow\quad (A \lor B) \leftrightarrow B
     \end{split} \\[1em]
-    \begin{split}
-        (A\land B) \to C & \quad\leftrightarrow\quad (A\to C) \lor (B\to C) \\ %nur in klassischer Logik
-        A \to (B\lor C) & \quad\leftrightarrow\quad (A\to B) \lor (A\to C) %nur in klassischer Logik
-    \end{split} \\[1em]
     A & \quad\to\quad \top && (\text{Wahres folgt aus Beliebigem}) \\
     \bot & \quad\to\quad A && (\text{ex falso quodlibet}) \\[1em]
     \begin{split}
@@ -60,9 +56,12 @@ Es gilt:
     \end{split} && (\text{Regeln von De Morgan}) \\[1em]
     A\to B & \quad\leftrightarrow\quad  \neg A \lor B \\
     \neg (A\to B) & \quad\leftrightarrow\quad  A \land \neg B \\[1em]
+    \begin{split}
+        (A\land B) \to C & \quad\leftrightarrow\quad (A\to C) \lor (B\to C) \\ %nur in klassischer Logik
+        A \to (B\lor C) & \quad\leftrightarrow\quad (A\to B) \lor (A\to C) %nur in klassischer Logik
+    \end{split} \\[1em]
     (A\to B)\to A &\quad \to\quad A && (\text{Peirce’sche Regel}) \\
-    A\to B & \quad \lor\quad B\to C \\
-    A \to(A\land B) &\quad \lor\quad B\to (A\land B)
+    A\to B & \quad \lor\quad B\to C
 \end{align*}
 \endgroup
 
@@ -77,7 +76,7 @@ In den folgenden Formeln seien
     \item $E,F$ zwei Eigenschaften.
     \item $R$ eine zweistellige Relation.
 \end{itemize}
-Für die mit einem (*) markierten Aussagen sei außerdem angenommen, dass es mindestens ein Objekt vom Typ der Variablen $x$ gibt. Es gilt:
+Für die mit einem (*) markierten Aussagen sei außerdem angenommen, dass es mindestens ein Objekt vom Typ der Variablen $x$ gibt. Für die Russellsche Antinomie sei zusätzlich gefordert, dass beide Variablen von $R$ vom selben Typ seien. Es gilt:
 \begingroup
 \allowdisplaybreaks
 \begin{align*}
@@ -95,14 +94,13 @@ Für die mit einem (*) markierten Aussagen sei außerdem angenommen, dass es min
     (\exists x : E(x)) \land A &  \quad\leftrightarrow\quad  \exists x : (E(x) \land A) \\
     (\forall x : E(x)) \lor A &  \quad\leftrightarrow\quad  \forall x :(E(x) \lor A) \\[1em] %nur in klassischer Logik
     \begin{split}
-        A \to( \exists x : E(x)) & \quad\leftrightarrow^*\quad \exists x : ( A\to E(x)) \\ %nur in klassischer Logik
-        (\forall x : E(x)) \to A & \quad\leftrightarrow^*\quad \exists x : (E(x) \to A) %nur in klassischer Logik
-    \end{split} \\[1em]
-    \begin{split}
         \nexists x: E(x) & \quad\leftrightarrow\quad \forall x: \neg E(x) \\
         \neg (\forall x: E(x)) & \quad\leftrightarrow\quad \exists x: \neg E(x) %nur in klassicher Logik
     \end{split} && (\text{Quantorennegationsregeln}) \\[1em]
-    \exists x\ \forall y :^* (E(x) & \to E(y)) && (``\text{\href{https://en.wikipedia.org/wiki/Drinker_paradox}{Drinker paradox}}") \\[1em] % nur in klassischer Logik
+    \begin{split}
+        A \to( \exists x : E(x)) & \quad\leftrightarrow^*\quad \exists x : ( A\to E(x)) \\ %nur in klassischer Logik
+        (\forall x : E(x)) \to A & \quad\leftrightarrow^*\quad \exists x : (E(x) \to A) %nur in klassischer Logik
+    \end{split} \\[1em]
     \nexists x \ \forall y : (R(x,y) & \leftrightarrow \neg R(y,y)) && (\text{Russellsche Antinomie})
 \end{align*}
 \endgroup
@@ -347,8 +345,8 @@ Dann gibt es natürliche Bijektionen:
     \Abb(X,Y) & \quad\cong\quad Y^X && (\text{Gleichwertigkeit von Abbildungen und Familien})
 \end{align*}
 \begin{align*}
-    \Abb(X,\prod X_i) & \quad\cong\quad \prod \Abb(X,X_i) && (\text{Universelle Eigenschaft des Produkts}) \\
-    \Abb(\bigsqcup X_i,X) & \quad\cong\quad \prod \Abb(X_i,X) && (\text{Universelle Eigenschaft des Koprodukts})
+    \Abb(X,\prod_{i\in I} X_i) & \quad\cong\quad \prod_{i\in I} \Abb(X,X_i) && (\text{Universelle Eigenschaft des Produkts}) \\
+    \Abb(\bigsqcup_{i\in I} X_i,X) & \quad\cong\quad \prod_{i\in I} \Abb(X_i,X) && (\text{Universelle Eigenschaft des Koprodukts})
 \end{align*}
 \begin{align*}
     \calP(X) & \quad\cong\quad \Abb(X,2) \quad\cong\quad 2^X \\
@@ -364,7 +362,7 @@ Dann gibt es natürliche Bijektionen:
         X \sqcup ( Y\sqcup Z) & \quad\cong\quad (X\sqcup Y)\sqcup Z \\
         X \sqcup Y & \quad\cong\quad Y\sqcup X
     \end{split} \\[1em]
-        0 \times X & \quad\cong\quad X && (\text{Absorbierende Null}) \\
+        0 \times X & \quad\cong\quad 0 && (\text{Absorbierende Null}) \\
         X \times (Y\sqcup Z) & \quad\cong\quad (X\times Y)\sqcup (X\times Z) && (\text{Distributivgesetz}) \\[1em]
     \begin{split}
         (X\times Y)^Z & \quad\cong\quad X^Z \times Y^Z \\
@@ -413,6 +411,8 @@ Dann gibt es natürliche Bijektionen:
     \item[Charakterisierung:] Äquivalente Beschreibung eines Objekts.
 
     \item[Echt:] wahlweise von der Bedeutung „strikt“ oder „nichttrivial“. Beispielsweise sind die \emph{echten Teiler} einer natürlichen Zahl $n$ alle Teiler von $n$ ausgenommen den „trivialen Teiler“ $n$ selbst. Die \emph{echten Teilmengen} einer Menge $M$ sind sind alle Teilmengen von $M$ mit Ausnahme der „trivialen Teilmenge“ $M$ (und eventuell $\emptyset$).
+
+    \item[Eindeutig bestimmt:] Ein mathematisches Objekt ist durch eine Eigenschaft eindeutig bestimmt, falls es kein anderes Objekt mit derselben Eigenschaft gibt. Beispielsweise ist der Mittelpunkt eines Kreises eindeutig bestimmt durch die Eigenschaft, dass er zu jedem Punkt auf dem Kreis denselben Abstand hat. Dagegen ist etwa die komplexe Quadratwurzel von $-1$ nicht eindeutig bestimmt, weil sowohl die komplexe Zahl $i$ als auch die Zahl $-i$ jeweils Quadratwurzeln von $-1$ sind.
     
     \item[Elementar:] Eine mathematische Aussage ist elementar, wenn ihr Beweis wenig Vorarbeit und Definitionen benötigt und auf wenige andere Sätze angewiesen ist . Andernfalls spricht man von einer \textbf{tiefen} Aussage. Werden im Laufe der Zeit neue Beweise gefunden, kann eine vormals tiefe Aussage elementar werden.
 
@@ -433,7 +433,7 @@ Dann gibt es natürliche Bijektionen:
     
     \item[Kanonisch:] Ein Objekt ist kanonisch, wenn es sich um ein Standard-Beispiel handelt, wenn es als Standard-Struktur eines anderen Objekts angesehen wird oder wenn es \emph{natürlich} (siehe unten) ist. Andernfalls heißt es \textbf{unkanonisch}. Beispielsweise besitzt der $\R^n$ eine kanonische Basis, die sogenannte Standardbasis, wohingegen der Folgenraum $\R^\N$ keine kanonische Basis besitzt, die Wahl einer Basis daher unkanonisch wäre. Noch ein Beispiel: die „kanonische“ Gruppenstruktur auf $\Z$ besteht aus der Addition $+$ -- schreiben Mathematiker von „der Gruppe $\Z$“, so ist damit so gut wie immer die Gruppe $(\Z,+)$ gemeint.
 
-    \item[Konstruktiv:] Ein Beweis oder eine Theorie sind „konstruktiv“, wenn jede ihrer Existenzaussagen durch ein Beispiel belegt werden kann. Andernfalls sind sie \textbf{nichtkonstruktiv}. Beispielsweise ist die Aussage „Jede surjektive Abbildung besitzt eine rechtsinverse“ nichtkonstruktiv.
+    \item[Konstruktiv:] Ein Beweis oder eine Theorie sind „konstruktiv“, wenn jede ihrer Existenzaussagen durch ein Beispiel belegt werden kann. Andernfalls sind sie \textbf{nichtkonstruktiv}. Beispielsweise ist die Aussage „Jede surjektive Abbildung besitzt eine Rechtsinverse“ nichtkonstruktiv.
     
     \item[Korollar:] Folgerung aus einem größeren mathematischen Satz.
 

--- a/cover.tex
+++ b/cover.tex
@@ -75,7 +75,7 @@
     \newgeometry{centering}
     
     \pdfbookmark[-1]{Griechisches Alphabet}{alphabet}
-    \centering{\Large\dgrau\textbf{Griechisches Alphabet}}
+    \centering{\dgrau\sffamily\Large\textbf{Griechisches Alphabet}}
     \vspace*{15mm}
     \large
     \begin{longtable}{lcccc}


### PR DESCRIPTION
- diverse Tippfehler und Formulierungen verbessert
- Das Beispiel zu N xN als „Gitter“ in §3.6 restlos entfernt, weil Bild verwirrend.
- Beispiel zu Mehrfach-Produkten in §6.4 ausgebaut.
- Aufgaben 3,4 vom Verknüpfungskapitel fusioniert zu einer „Vollzieht den Beweis nach“-Aufgabe.